### PR TITLE
ci: PR을 넣으면 두 개의 워크플로우가 실행되는 원인 해결

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,10 +9,6 @@ name: Java CI with Gradle
 
 # 동작 조건 설정: main, develop 브랜치에 pull request이 merge될 경우 동작
 on:
-  pull_request:
-    types:
-      - closed
-    branches: [ "main", "develop"]
   push:
     branches: [ "main", "develop" ]
 


### PR DESCRIPTION
- PR을 병합하면 GitHub Actions에서 두 개의 워크플로우가 실행되는 이유는 pull_request 이벤트와 push 이벤트 모두 트리거되기 때문
- pull_request 이벤트를 제거하고 push 이벤트만 사용
- 이렇게 하면 PR이 merge될 때만 CI/CD가 실행되고, PR이 닫힐 때는 실행되지 않음