### PR TITLE
JWT에 linked_id 추가&아이-부모 계정 연동 관련 로직(미완) & Security Context에 인증객체 저장

### DIFF
--- a/src/main/java/com/example/iplan/Controller/AccountController.java
+++ b/src/main/java/com/example/iplan/Controller/AccountController.java
@@ -1,0 +1,75 @@
+package com.example.iplan.Controller;
+
+import com.example.iplan.DTO.AccountRequestDTO;
+import com.example.iplan.Domain.PendingAccountRequest;
+import com.example.iplan.Repository.AccountRepository;
+import com.example.iplan.Service.AccountService;
+import com.example.iplan.auth.UserRepository;
+import com.example.iplan.auth.UserRole;
+import com.example.iplan.auth.Users;
+import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@Tag(name = "Account CRUD", description = "계정 연동 관련 api 요청")
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+@Validated
+@RequestMapping("/api")
+public class AccountController {
+    private final AccountService accountService;
+
+    @Operation(summary = "부모가 아이 계정 연동 요청을 보냄 POST", description = "해당 요청을 PendingAccountRequest 저장")
+    @PostMapping("/parent/link-child")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> parentAccountRequest(@RequestBody @NotNull AccountRequestDTO requestDTO, @AuthenticationPrincipal CustomOAuth2UserDetails user)
+            throws ExecutionException, InterruptedException {
+        log.info("Account API from parent received!");
+
+        String childNickname = requestDTO.getChildNickname();
+        String parentNickname = user.getUsername();
+
+        return accountService.sendAccountRequest(childNickname, parentNickname);
+    }
+
+    @GetMapping("/child/pending-requests")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> getChildPendingRequests(@AuthenticationPrincipal String childNickname) {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            List<AccountRequestDTO> requests = accountService.getPendingRequestsForChild(childNickname);
+
+            if (requests.isEmpty()) {
+                response.put("success", false);
+                response.put("message", "도착한 연동 요청이 없습니다.");
+            } else {
+                response.put("success", true);
+                response.put("requests", requests);
+            }
+
+            return ResponseEntity.ok(response);
+        } catch (ExecutionException | InterruptedException e) {
+            response.put("success", false);
+            response.put("message", "연동 요청을 가져오는 데 실패했습니다. Error: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+
+}

--- a/src/main/java/com/example/iplan/Controller/AccountController.java
+++ b/src/main/java/com/example/iplan/Controller/AccountController.java
@@ -51,9 +51,10 @@ public class AccountController {
 
     @GetMapping("/child/pending-requests")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> getChildPendingRequests(@AuthenticationPrincipal String childNickname) {
+    public ResponseEntity<Map<String, Object>> getChildPendingRequests(@AuthenticationPrincipal CustomOAuth2UserDetails user) {
         Map<String, Object> response = new HashMap<>();
         try {
+            String childNickname = user.getUsername();
             List<AccountRequestDTO> requests = accountService.getPendingRequestsForChild(childNickname);
 
             if (requests.isEmpty()) {

--- a/src/main/java/com/example/iplan/Controller/CalendarController.java
+++ b/src/main/java/com/example/iplan/Controller/CalendarController.java
@@ -2,6 +2,7 @@ package com.example.iplan.Controller;
 
 import com.example.iplan.Domain.DayData;
 import com.example.iplan.Service.CalendarService;
+import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,7 +33,7 @@ public class CalendarController {
     /**
      * (달력 탭) 해당 년월의 도장(성공)상황 모두 가져오기
      * @param yearMonth
-     * @param userId
+     * @param user
      * @return
      * @throws ExecutionException
      * @throws InterruptedException
@@ -43,16 +44,17 @@ public class CalendarController {
             })
     @GetMapping("/{yearMonth}")
     public ResponseEntity<Map<String, Object>> getMonthCalendarData
-    (@PathVariable @Parameter(description = "원하는 년/월", example = "2025-01") String yearMonth, @AuthenticationPrincipal String userId) {
+    (@PathVariable @Parameter(description = "원하는 년/월", example = "2025-01") String yearMonth, @AuthenticationPrincipal CustomOAuth2UserDetails user) {
 
-        return calendarService.getAllCalendarData(yearMonth, userId);
+        String nickname = user.getUsername();
+        return calendarService.getAllCalendarData(yearMonth, nickname);
 
     }
 
     /**
      * (달력 탭) 특정 날짜 클릭시 해당 날짜의 데이터 모두 가져오기
      * @param yearMonthDate
-     * @param userId
+     * @param user
      * @return
      * @throws ExecutionException
      * @throws InterruptedException
@@ -66,7 +68,9 @@ public class CalendarController {
     })
     @GetMapping("/showTargetDateData/{yearMonthDate}")
     public ResponseEntity<Map<String, Object>> getTargetDateData
-    (@PathVariable @Parameter(description = "원하는 년/월/일", example = "2025-01-22") String yearMonthDate, @AuthenticationPrincipal String userId) throws ExecutionException, InterruptedException {
-        return calendarService.getTargetDateData(yearMonthDate, userId);
+    (@PathVariable @Parameter(description = "원하는 년/월/일", example = "2025-01-22") String yearMonthDate, @AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
+
+        String nickname = user.getUsername();
+        return calendarService.getTargetDateData(yearMonthDate, nickname);
     }
 }

--- a/src/main/java/com/example/iplan/Controller/PlanCategoryController.java
+++ b/src/main/java/com/example/iplan/Controller/PlanCategoryController.java
@@ -2,6 +2,7 @@ package com.example.iplan.Controller;
 
 import com.example.iplan.DTO.PlanCategoryDTO;
 import com.example.iplan.Service.PlanCategoryService;
+import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import com.google.firebase.database.annotations.NotNull;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,15 +30,17 @@ public class PlanCategoryController {
     })
     @PostMapping("/addition/{categoryName}")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> additionPlanCategory(@PathVariable @Parameter(description = "추가하고싶은 카테고리 이름", example = "숙제") String categoryName, @AuthenticationPrincipal String userId){
-        return planCategoryService.addCategory(userId, categoryName);
+    public ResponseEntity<Map<String, Object>> additionPlanCategory(@PathVariable @Parameter(description = "추가하고싶은 카테고리 이름", example = "숙제") String categoryName, @AuthenticationPrincipal CustomOAuth2UserDetails user){
+        String nickname = user.getUsername();
+        return planCategoryService.addCategory(nickname, categoryName);
     }
 
     @Operation(summary = "카테고리 GET", description = "사용자가 추가한 카테고리를 모두 보여준다.")
     @GetMapping("/categoryList/")
     @ResponseBody
-    public List<PlanCategoryDTO> findAllUserCategory(@AuthenticationPrincipal String userId) throws ExecutionException, InterruptedException {
-        return planCategoryService.findAllPlanCategory(userId);
+    public List<PlanCategoryDTO> findAllUserCategory(@AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
+        String nickname = user.getUsername();
+        return planCategoryService.findAllPlanCategory(nickname);
     }
 
     @Operation(summary = "카테고리 삭제", parameters = {

--- a/src/main/java/com/example/iplan/Controller/PlanChildController.java
+++ b/src/main/java/com/example/iplan/Controller/PlanChildController.java
@@ -3,6 +3,7 @@ package com.example.iplan.Controller;
 import com.example.iplan.DTO.PlanChildDTO;
 import com.example.iplan.DTO.ScreenTimeDTO;
 import com.example.iplan.Service.PlanChildService;
+import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import com.google.firebase.database.annotations.NotNull;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -37,7 +38,7 @@ public class PlanChildController {
     /**
      * (목표 탭에서 계획 추가하기 버튼 클릭시) 해당 날짜에 단일 계획을 추가한다
      * @param request PlanChildDto
-     * @param nickname 유저 아이디
+     * @param user 인증객체
      * @return 성공 여부 및 오류 메세지
      * @throws ExecutionException
      * @throws InterruptedException
@@ -48,10 +49,12 @@ public class PlanChildController {
     })
     @PostMapping("/addition")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> additionPlan(@RequestBody @NotNull PlanChildDTO request, @AuthenticationPrincipal String nickname)
+    public ResponseEntity<Map<String, Object>> additionPlan(@RequestBody @NotNull PlanChildDTO request, @AuthenticationPrincipal CustomOAuth2UserDetails user)
             throws ExecutionException, InterruptedException {
         log.info("Child plan addition API received!");
-        return planChildService.postChildNewPlan(request, nickname);
+
+        String childNickname = user.getUsername();
+        return planChildService.postChildNewPlan(request, childNickname);
     }
 
     /**
@@ -66,16 +69,16 @@ public class PlanChildController {
             })
     @GetMapping("/dayPlanListTitle/{targetDate}")
     public ResponseEntity<Map<String, Object>> showPlanList
-    (@AuthenticationPrincipal String uid,
+    (@AuthenticationPrincipal CustomOAuth2UserDetails user,
      @PathVariable @Parameter(description = "원하는 년/월/일", example = "2025-01-15") String targetDate) throws ExecutionException, InterruptedException {
-
-        Map<String, Object> response = planChildService.findAllPlanList(uid, targetDate);
+        String childNickname = user.getUsername();
+        Map<String, Object> response = planChildService.findAllPlanList(childNickname, targetDate);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     /**
      * 사용자의 전체 계획 목록 반환(날짜 상관 없음)
-     * @param nickname
+     * @param user
      * @return
      * @throws ExecutionException
      * @throws InterruptedException
@@ -83,8 +86,8 @@ public class PlanChildController {
     @Operation(summary = "계획 목록 조회 GET", description = "해당 사용자의 전체 계획 목록을 가져온다.")
     @GetMapping("/list")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> getPlanList(@AuthenticationPrincipal String nickname) throws ExecutionException, InterruptedException {
-
+    public ResponseEntity<Map<String, Object>> getPlanList(@AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
+        String nickname = user.getUsername();
         Map<String, Object> response = planChildService.getAllPlans(nickname);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
@@ -109,7 +112,7 @@ public class PlanChildController {
     /**
      * 특정 계획 수정
      * @param request
-     * @param nickname
+     * @param user
      * @return
      * @throws ExecutionException
      * @throws InterruptedException
@@ -117,9 +120,10 @@ public class PlanChildController {
     @Operation(summary = "단일 계획 업데이트 UPDATE", description = "특정 계획 데이터 값을 바꾼다.(계획 달성 체크의 경우도 해당), Id 필수")
     @PatchMapping("/update-plan")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> updatePlan(@RequestBody @NotNull PlanChildDTO request, @AuthenticationPrincipal String nickname) throws ExecutionException, InterruptedException {
+    public ResponseEntity<Map<String, Object>> updatePlan(@RequestBody @NotNull PlanChildDTO request, @AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
         log.info("Child's plan 'is_completed' update");
-        return planChildService.updateOriginalPlan(request, nickname);
+        String childNickname = user.getUsername();
+        return planChildService.updateOriginalPlan(request, childNickname);
     }
 
     /**
@@ -147,7 +151,8 @@ public class PlanChildController {
     @Operation(summary = "스크린 타임 목표 설정", description = "목표 탭에서 스크린 타임 측정 클릭시 목표 시간 설정")
     @PostMapping("/screen-time-set")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> setScreenTime(@RequestBody ScreenTimeDTO screenTime, @AuthenticationPrincipal String uid){
-        return planChildService.SetScreenTime(screenTime, uid);
+    public ResponseEntity<Map<String, Object>> setScreenTime(@RequestBody ScreenTimeDTO screenTime, @AuthenticationPrincipal CustomOAuth2UserDetails user){
+        String childNickname = user.getUsername();
+        return planChildService.SetScreenTime(screenTime, childNickname);
     }
 }

--- a/src/main/java/com/example/iplan/Controller/RewardChildController.java
+++ b/src/main/java/com/example/iplan/Controller/RewardChildController.java
@@ -49,10 +49,12 @@ public class RewardChildController {
                     }))
     @PostMapping
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> saveReward(@RequestBody @NotNull RewardChildDTO rewardDto, @AuthenticationPrincipal String nickname) throws ExecutionException, InterruptedException {
-        log.info("Received RewardChildDTO: {}, AuthenticationPrincipal email: {}", rewardDto, nickname);
+    public ResponseEntity<Map<String, Object>> saveReward(@RequestBody @NotNull RewardChildDTO rewardDto, @AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
 
-        return rewardChildService.saveReward(rewardDto, nickname);
+        String childNickname = user.getUsername();
+        log.info("Received RewardChildDTO: {}, AuthenticationPrincipal email: {}", rewardDto, childNickname);
+
+        return rewardChildService.saveReward(rewardDto, childNickname);
     }
 
     /**
@@ -87,10 +89,11 @@ public class RewardChildController {
             @RequestParam int year,
             @RequestParam int month,
             @RequestParam int day,
-            @AuthenticationPrincipal String nickname) {
+            @AuthenticationPrincipal CustomOAuth2UserDetails user) {
 
         Map<String, Object> response = new HashMap<>();
         try {
+            String nickname = user.getUsername();
             RewardChildDTO reward = rewardChildService.getDailyReward(nickname, year, month, day);
 
             if (reward != null) {
@@ -111,15 +114,16 @@ public class RewardChildController {
 
     /**
      * 사용자의 모든 보상을 조회
-     * @param nickname 사용자 이름 (AuthenticationPrincipal로 인증된 사용자)
+     * @param user
      * @return 모든 보상 목록
      */
     @Operation(summary = "모든 보상 목록 GET", description = "해당 사용자의 모든 보상 목록을 조회한다.")
     @GetMapping("/all-rewards")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> getAllRewards(@AuthenticationPrincipal String nickname) {
+    public ResponseEntity<Map<String, Object>> getAllRewards(@AuthenticationPrincipal CustomOAuth2UserDetails user) {
         Map<String, Object> response = new HashMap<>();
         try {
+            String nickname = user.getUsername();
             List<RewardChildDTO> rewards = rewardChildService.getAllRewards(nickname);
 
             if (rewards.isEmpty()) {
@@ -153,9 +157,10 @@ public class RewardChildController {
                     }))
     @PatchMapping("/update")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> updateReward(@RequestBody @NotNull RewardChildDTO rewardDto, @AuthenticationPrincipal String nickname) throws ExecutionException, InterruptedException {
-        log.info("Received RewardChildDTO for update reward: {}, AuthenticationPrincipal email: {}", rewardDto, nickname);
-        return rewardChildService.updateReward(rewardDto, nickname);
+    public ResponseEntity<Map<String, Object>> updateReward(@RequestBody @NotNull RewardChildDTO rewardDto, @AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
+        String childNickname = user.getUsername();
+        log.info("Received RewardChildDTO for update reward: {}, AuthenticationPrincipal email: {}", rewardDto, childNickname);
+        return rewardChildService.updateReward(rewardDto, childNickname);
     }
 
     /**

--- a/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
+++ b/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
@@ -1,6 +1,7 @@
 package com.example.iplan.Controller;
 
 import com.example.iplan.Service.ScreenTimeService;
+import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,8 +23,9 @@ public class ScreenTimeController {
     private final ScreenTimeService screenTimeService;
 
     @PostMapping("/upload")
-    public ResponseEntity<Map<String, Object>> uploadScreenTimeFile(@RequestParam("image")MultipartFile image, @AuthenticationPrincipal String user_id) throws IOException, ExecutionException, InterruptedException {
-        return screenTimeService.uploadScreenTimeImage(image, user_id);
+    public ResponseEntity<Map<String, Object>> uploadScreenTimeFile(@RequestParam("image")MultipartFile image, @AuthenticationPrincipal CustomOAuth2UserDetails user) throws IOException, ExecutionException, InterruptedException {
+        String childNickname = user.getUsername();
+        return screenTimeService.uploadScreenTimeImage(image, childNickname);
     }
 
 }

--- a/src/main/java/com/example/iplan/DTO/AccountRequestDTO.java
+++ b/src/main/java/com/example/iplan/DTO/AccountRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.iplan.DTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "계정 연동 요청 DTO")
+public class AccountRequestDTO {
+    private String childNickname;
+    private String parentNickname;
+    private boolean approved; // 자녀가 승인했는지 여부
+}

--- a/src/main/java/com/example/iplan/Domain/PendingAccountRequest.java
+++ b/src/main/java/com/example/iplan/Domain/PendingAccountRequest.java
@@ -1,0 +1,22 @@
+package com.example.iplan.Domain;
+
+import com.google.cloud.firestore.annotation.DocumentId;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "계정 연동 요청 엔티티")
+public class PendingAccountRequest {
+    @DocumentId
+    private String id;
+
+    private String childNickname;
+    private String parentNickname;
+    private boolean approved; // 자녀가 승인했는지 여부
+}

--- a/src/main/java/com/example/iplan/Repository/AccountRepository.java
+++ b/src/main/java/com/example/iplan/Repository/AccountRepository.java
@@ -1,0 +1,42 @@
+package com.example.iplan.Repository;
+
+import com.example.iplan.DTO.AccountRequestDTO;
+import com.example.iplan.Domain.PendingAccountRequest;
+import com.example.iplan.Repository.DefaultFirebaseRepository.DefaultFirebaseDBRepository;
+import com.google.cloud.firestore.Firestore;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@Repository
+public class AccountRepository extends DefaultFirebaseDBRepository<PendingAccountRequest> {
+    public AccountRepository(Firestore firestore) {
+        super(firestore);
+        setEntityClass(PendingAccountRequest.class);
+        setCollectionName("PendingAccountRequest");
+    }
+
+    public List<PendingAccountRequest> findByChildNicknameAndApproved(String childNickname, boolean approved)
+            throws ExecutionException, InterruptedException {
+
+        Map<String, Object> filters = Map.of(
+                "childNickname", childNickname,
+                "approved", approved
+        );
+
+        return findAllByFields(filters);
+    }
+
+    /**
+     * DTO 변환
+     */
+    public AccountRequestDTO convertToDTO(PendingAccountRequest entity) {
+        return AccountRequestDTO.builder()
+                .childNickname(entity.getChildNickname())
+                .parentNickname(entity.getParentNickname())
+                .approved(entity.isApproved())
+                .build();
+    }
+}

--- a/src/main/java/com/example/iplan/Repository/RewardChildRepository.java
+++ b/src/main/java/com/example/iplan/Repository/RewardChildRepository.java
@@ -110,6 +110,7 @@ public class RewardChildRepository extends DefaultFirebaseDBRepository<RewardChi
                 .post_month(rewardChild.getPost_month())
                 .post_day(rewardChild.getPost_day())
                 .rewarded(rewardChild.isRewarded())
+                .success(rewardChild.isSuccess())
                 .build();
     }
 }

--- a/src/main/java/com/example/iplan/Service/AccountService.java
+++ b/src/main/java/com/example/iplan/Service/AccountService.java
@@ -1,0 +1,96 @@
+package com.example.iplan.Service;
+
+import com.example.iplan.Domain.PendingAccountRequest;
+import com.example.iplan.DTO.AccountRequestDTO;
+import com.example.iplan.ExceptionHandler.CustomException;
+import com.example.iplan.Repository.AccountRepository;
+import com.example.iplan.auth.UserRepository;
+import com.example.iplan.auth.UserRole;
+import com.example.iplan.auth.Users;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 부모가 자녀 닉네임을 입력하여 연동 요청을 보냄
+     */
+    public ResponseEntity<Map<String, Object>> sendAccountRequest(String childNickname, String parentNickname)
+            throws ExecutionException, InterruptedException {
+
+        Map<String, Object> response = new HashMap<>();
+
+        // 1. 자녀 유저 조회
+        Users childUser = userRepository.findByNickname(childNickname)
+                .orElseThrow(() -> new CustomException("해당 닉네임의 자녀를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        // 2. 자녀인지 확인
+        if (childUser.getAuthority() != UserRole.CHILD) {
+            throw new CustomException("입력한 닉네임은 자녀 계정이 아닙니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 3. PendingAccountRequest 생성
+        PendingAccountRequest request = PendingAccountRequest.builder()
+                .childNickname(childNickname)
+                .parentNickname(parentNickname)
+                .approved(false)
+                .build();
+
+        // 4. 저장
+        accountRepository.saveWithAutoIncrement(request);
+
+        // 5. 응답 반환
+        response.put("success", true);
+        response.put("message", "자녀에게 연동 요청이 전송되었습니다.");
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * 자녀가 부모의 연동 요청을 확인
+     * 아직 승인되지 않은 요청만 필터링 (approved == false)
+     * 반환값은 List<AccountRequestDTO> 형태
+     */
+    public List<AccountRequestDTO> getPendingRequestsForChild(String childNickname) throws ExecutionException, InterruptedException {
+        // 자녀가 존재하는지 확인
+        Users user = userRepository.findByNickname(childNickname)
+                .orElseThrow(() -> new CustomException("자녀 닉네임에 해당하는 사용자가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
+
+        log.info("Get pending account requests for child [{}] started!", childNickname);
+
+        try {
+            // 승인되지 않은 요청만 필터링
+            List<PendingAccountRequest> pendingList = accountRepository.findByChildNicknameAndApproved(childNickname, false);
+
+            if (pendingList.isEmpty()) {
+                log.info("No pending account requests found for child: {}", childNickname);
+            } else {
+                log.info("Pending account requests retrieved. Count: {}", pendingList.size());
+            }
+
+            // DTO 변환 후 반환
+            return pendingList.stream()
+                    .map(accountRepository::convertToDTO)
+                    .toList();
+
+        } catch (Exception e) {
+            log.error("Error while fetching account requests for child [{}]: {}", childNickname, e.getMessage());
+            throw new ExecutionException("계정 연동 요청을 가져오는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/OAuth2UserInfo.java
@@ -74,7 +74,7 @@ public class OAuth2UserInfo {
                 .name(name)
                 .email(email)
                 .password("") // OAuth2 로그인 사용자는 비밀번호 없음
-                .authority(UserRole.CHILD) // 기본 권한 설정
+                .authority(UserRole.UNKNOWN) // 기본 권한 설정
                 .build();
     }
 

--- a/src/main/java/com/example/iplan/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/iplan/config/jwt/JwtTokenProvider.java
@@ -41,6 +41,7 @@ public class JwtTokenProvider {
         CustomOAuth2UserDetails userDetails = (CustomOAuth2UserDetails) authentication.getPrincipal();
 
         String nickname = userDetails.getUser().getNickname();
+        String linked_id = userDetails.getUser().getLinked_id();
 
         // 사용자 권한 리스트 추출 (ROLE_CHILD, ROLE_PARENT → CHILD, PARENT 변환)
         // authentication.getAuthorities()에서 GrantedAuthority의 getAuthority()를 호출하여 문자열(ROLE_CHILD, ROLE_PARENT)을 가져옴
@@ -52,7 +53,7 @@ public class JwtTokenProvider {
         // 이때, 문자열이 아니라 Enum 값(CHILD, PARENT)을 저장하려면 UserRole.fromString()을 사용해 변환
         UserRole role = UserRole.fromString(roleString); // 문자열을 Enum(UserRole)로 변환
 
-        log.info("User nickname: {}, role: {}", nickname, role);
+        log.info("User nickname: {}, role: {}, linked_id: {}", nickname, role, linked_id);
 
         long now = (new Date()).getTime();
 
@@ -61,6 +62,7 @@ public class JwtTokenProvider {
         String accessToken = Jwts.builder()
                 .setSubject(nickname)
                 .claim("role", role.name()) // Enum 값 저장 (CHILD, PARENT)
+                .claim("linked_id", linked_id)
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -86,6 +88,9 @@ public class JwtTokenProvider {
         log.info("[JwtTokenProvider getAuthentication]");
         log.info("claim.getSubject is 'Nickname' = {}", claims.getSubject());
 
+        String nickname = claims.getSubject();
+        String linked_id = claims.get("linked_id", String.class);
+
         // role 정보가 없는 경우 예외 처리
         if (claims.get("role") == null) {
             throw new RuntimeException("JWT에 role 정보가 없습니다.");
@@ -105,18 +110,19 @@ public class JwtTokenProvider {
                 Users.builder()
                         .name("")
                         .email("")
-                        .nickname(claims.getSubject())  // 토큰에서 추출한..
+                        .nickname(nickname)  // 토큰에서 추출한..
                         .password("")
                         .authority(role)    // Enum 값 그대로 사용
+                        .linked_id(linked_id)
                         .build()
         );
 
         // Spring Security에서 UsernamePasswordAuthenticationToken을 생성할 때 첫 번째 매개변수는 Principal(사용자 정보) 역할을 함
         // -> principal 대신 nickname을 매개변수로 넣어서 @AuthenticationPrincipal에서 바로 nickname 가져올 수 있도록 함!!
-        String nickname = claims.getSubject();
 
-        // 기존에는 UsernamePasswordAuthenticationToken(principal, "", authorities)
-        return new UsernamePasswordAuthenticationToken(nickname, "", authorities);
+//        String nickname = claims.getSubject();
+//        return new UsernamePasswordAuthenticationToken(nickname, "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
     // JWT 유효성 검증

--- a/src/main/java/com/example/iplan/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/iplan/config/jwt/JwtTokenProvider.java
@@ -89,7 +89,7 @@ public class JwtTokenProvider {
         log.info("claim.getSubject is 'Nickname' = {}", claims.getSubject());
 
         String nickname = claims.getSubject();
-        String linked_id = claims.get("linked_id", String.class);
+        String linked_id = claims.get("linked_id", String.class); // claim 없으면 null 반환
 
         // role 정보가 없는 경우 예외 처리
         if (claims.get("role") == null) {


### PR DESCRIPTION
1. 아이-부모 계정 연동 구현 시에 프론트에서 앱을 실행할 때 마다(로그인할 때마다) 부모 측에서 연동 여부를 체크해야하는데, 이때 매번 서버에 요청을 보내지 말고
토큰에 담아서 보내기!! -> 디코딩해서 linked_id 확인 가능

2. Security Context에서 linked_id도 불러올 수 있게 인증객체(CustomOAuth2UserDetails) 저장
- 기존에는 nickname을 매개변수로 하여 바로 @AuthenticationPrincipal에서 가져옴