### PR TITLE
Refact: 업로드 받은 스크린타임 사진 텍스트 추출 로직 수정 및 기타 환경설정 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ COPY ${JAR_FILE} app.jar
 # Firebase 서비스 계정 파일 복사
 COPY ./src/main/resources/iplan-firebase.json /app/iplan-firebase.json
 
+# Google Application Credentials 서비스 계정 파일 복사
+COPY ./src/main/resources/iplan-3e9c2-feef2236cd5b.json /app/iplan-3e9c2-feef2236cd5b.json
+
 # 실행 명령어
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
 ENV FIREBASE_CONFIG_PATH=/app/iplan-firebase.json
+ENV GOOGLE_APPLICATION_CREDENTIALS=/app/iplan-3e9c2-feef2236cd5b.json

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 		exclude group: 'commons-logging', module: 'commons-logging'
 	}
 	implementation 'org.springframework:spring-jcl'
+	implementation 'io.grpc:grpc-protobuf-lite:1.62.2'
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,8 +12,6 @@ services:
       - "8080:8080"
     environment:
       - FIREBASE_CONFIG_PATH=/app/iplan-firebase.json
-    volumes:
-      - ./src/main/resources/iplan-firebase.json:/app/iplan-firebase.json
 
   app3:
     image: hanni/test1

--- a/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
+++ b/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
@@ -27,13 +27,15 @@ public class ScreenTimeController {
     }
 
     @GetMapping("/showTimeSet/{targetDate}")
-    public ResponseEntity<Map<String, Object>> GetScreenTime(@AuthenticationPrincipal String user_id, @PathVariable String targetDate) throws ExecutionException, InterruptedException{
-        return screenTimeService.getScreenTime(user_id, targetDate);
+    public ResponseEntity<Map<String, Object>> GetScreenTime(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws ExecutionException, InterruptedException{
+        String childNickname = user.getUsername();
+        return screenTimeService.getScreenTime(childNickname, targetDate);
     }
 
     @GetMapping("/showScreenTimeGraph/{targetDate}")
-    public ResponseEntity<Map<String, Object>> GetScreenTimeGraph(@AuthenticationPrincipal String user_id, @PathVariable String targetDate) throws ExecutionException, InterruptedException{
-        return screenTimeService.getScreenTimeGraph(user_id, targetDate);
+    public ResponseEntity<Map<String, Object>> GetScreenTimeGraph(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws ExecutionException, InterruptedException{
+        String childNickname = user.getUsername();
+        return screenTimeService.getScreenTimeGraph(childNickname, targetDate);
     }
 
 }

--- a/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
+++ b/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
@@ -1,8 +1,14 @@
 package com.example.iplan.Controller;
 
+import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Service.ScreenTimeService;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -10,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
@@ -21,9 +28,21 @@ public class ScreenTimeController {
     private final ScreenTimeService screenTimeService;
 
     @PostMapping("/upload")
-    public ResponseEntity<Map<String, Object>> uploadScreenTimeFile(@RequestParam("image")MultipartFile image, @AuthenticationPrincipal CustomOAuth2UserDetails user) throws IOException, ExecutionException, InterruptedException {
+    public ResponseEntity<Map<String, Object>> uploadScreenTimeFile(@RequestParam("image")MultipartFile image, @AuthenticationPrincipal CustomOAuth2UserDetails user, @RequestParam(value = "installed_apps", required = false) String installedAppsJson) throws ExecutionException, InterruptedException {
         String childNickname = user.getUsername();
-        return screenTimeService.uploadScreenTimeImage(image, childNickname);
+
+        List<String> installedApps = null;
+
+        if(installedAppsJson != null && !installedAppsJson.isEmpty()){
+            try{
+                ObjectMapper objectMapper = new ObjectMapper();
+                installedApps = objectMapper.readValue(installedAppsJson, new TypeReference<>() {});
+            } catch (JsonProcessingException e) {
+                throw new CustomException("앱 목록 파싱 실패", HttpStatus.BAD_REQUEST);
+            }
+        }
+
+        return screenTimeService.uploadScreenTimeImage(image, childNickname, installedApps);
     }
 
     @GetMapping("/showTimeSet/{targetDate}")

--- a/src/main/java/com/example/iplan/Domain/InstalledApps.java
+++ b/src/main/java/com/example/iplan/Domain/InstalledApps.java
@@ -1,0 +1,26 @@
+package com.example.iplan.Domain;
+
+import com.google.cloud.firestore.annotation.DocumentId;
+import com.google.firebase.database.annotations.NotNull;
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InstalledApps {
+
+    @DocumentId
+    private String id;
+
+    @NotNull
+    private String user_id;
+
+    @NotNull
+    private List<String> installed_apps;
+}

--- a/src/main/java/com/example/iplan/Repository/InstalledAppsRepository.java
+++ b/src/main/java/com/example/iplan/Repository/InstalledAppsRepository.java
@@ -1,0 +1,25 @@
+package com.example.iplan.Repository;
+
+import com.example.iplan.Domain.InstalledApps;
+import com.example.iplan.Repository.DefaultFirebaseRepository.DefaultFirebaseDBRepository;
+import com.google.cloud.firestore.Firestore;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@Repository
+public class InstalledAppsRepository extends DefaultFirebaseDBRepository<InstalledApps> {
+    public InstalledAppsRepository(Firestore firestore){
+        super(firestore);
+        setEntityClass(InstalledApps.class);
+        setCollectionName("InstalledApps");
+    }
+
+    public InstalledApps findByUserId(String user_id) throws ExecutionException, InterruptedException {
+        Map<String, Object> filters = Map.of(
+                "user_id", user_id
+        );
+        return findByFields(filters);
+    }
+}

--- a/src/main/java/com/example/iplan/Service/PlanCategoryService.java
+++ b/src/main/java/com/example/iplan/Service/PlanCategoryService.java
@@ -33,7 +33,7 @@ public class PlanCategoryService {
                 .build();
 
         try{
-            planCategoryRepository.save(planCategory);
+            planCategoryRepository.saveWithAutoIncrement(planCategory);
         }
         catch (Exception e){
             throw new CustomException("계획 카테고리 추가에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/example/iplan/Service/PlanChildService.java
+++ b/src/main/java/com/example/iplan/Service/PlanChildService.java
@@ -62,7 +62,7 @@ public class PlanChildService {
             response.put("message", "계획이 정상적으로 추가되었습니다.");
             response.put("id", planPost.getId());
 
-            response = dayDataService.GenerateOrSaveDayPlanData(response, planPost, user_id);
+            //response = dayDataService.GenerateOrSaveDayPlanData(response, planPost, user_id);
             return new ResponseEntity<>(response, HttpStatus.OK);
         } else {
             throw new CustomException("유저 아이디가 올바르지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
@@ -240,7 +240,7 @@ public class PlanChildService {
                 .build();
 
         try{
-            setScreenTimeRepository.save(newScreenTime);
+            setScreenTimeRepository.saveWithAutoIncrement(newScreenTime);
         }
         catch(Exception e){
             throw new CustomException("스크린 타임 설정에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/example/iplan/Service/RewardParentsService.java
+++ b/src/main/java/com/example/iplan/Service/RewardParentsService.java
@@ -55,7 +55,7 @@ public class RewardParentsService {
                     .build();
 
             // 3. RewardParents 저장
-            rewardParentsRepository.save(newRewardParents);
+            rewardParentsRepository.saveWithAutoIncrement(newRewardParents);
 
             // 4. RewardChild의 보상 지급 상태를 업데이트하고 저장
             reward.setRewarded(true);

--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -1,9 +1,11 @@
 package com.example.iplan.Service;
 
+import com.example.iplan.Domain.InstalledApps;
 import com.example.iplan.Domain.ScreenTime;
 import com.example.iplan.Domain.ScreenTimeOCRResult;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.GetScreenTimeOCRRepository;
+import com.example.iplan.Repository.InstalledAppsRepository;
 import com.example.iplan.Repository.SetScreenTimeRepository;
 import com.example.iplan.util.SimplePair;
 import com.google.cloud.vision.v1.*;
@@ -39,6 +41,8 @@ public class ScreenTimeService {
     private final SetScreenTimeRepository setScreenTimeRepository;
 
     private final GetScreenTimeOCRRepository getScreenTimeOCRRepository;
+
+    private final InstalledAppsRepository installedAppsRepository;
 
     public ResponseEntity<Map<String, Object>> getScreenTimeGraph(String user_id, String targetDate) throws ExecutionException, InterruptedException{
         Map<String, Object> response = new HashMap<>();
@@ -87,88 +91,108 @@ public class ScreenTimeService {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Object>> uploadScreenTimeImage(@RequestParam("file") MultipartFile image, String user_id) throws IOException, ExecutionException, InterruptedException {
+    public ResponseEntity<Map<String, Object>> uploadScreenTimeImage(@RequestParam("file") MultipartFile image, String user_id, List<String> installedApps) throws ExecutionException, InterruptedException {
         Map<String, Object> response = new HashMap<>();
+        InstalledApps savedInstalledApps = installedAppsRepository.findByUserId(user_id);
 
         if(user_id == null){
             throw new CustomException("유저 상태를 확인해주세요.", HttpStatus.BAD_REQUEST);
         }
 
-        try {
-            // 1. 임시 파일로 저장
-            String filename = image.getOriginalFilename();
-            if (filename == null || filename.isEmpty()) {
-                throw new CustomException("파일 이름이 비어 있습니다.", HttpStatus.BAD_REQUEST);
-            }
+        if(installedApps != null){
+            System.out.println("설치된 어플 목록을 프론트로부터 새로 받았습니다.");
+            InstalledApps newInstalledApps = InstalledApps.builder()
+                    .user_id(user_id)
+                    .installed_apps(installedApps).build();
 
-            Path tempDir = Files.createTempDirectory("upload");
-            System.out.println("Temporary directory created: " + tempDir);
-
-            Path filePath = tempDir.resolve(filename);
-            System.out.println("File will be saved at: " + filePath);
-
-            // 파일 저장
-            try {
-                Files.write(filePath, image.getBytes());
-                System.out.println("File written successfully to: " + filePath);
-            } catch (IOException e) {
-                throw new CustomException("파일 저장 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
-            }
-
-            // 2. 파일 생성 시간 확인(캡쳐 시간 확인)
-            BasicFileAttributes attr = Files.readAttributes(filePath, BasicFileAttributes.class);
-            FileTime creationTime = attr.creationTime();
-            LocalDateTime creationDateTime = creationTime
-                    .toInstant()
-                    .atZone(ZoneId.systemDefault())
-                    .toLocalDateTime();
-
-            System.out.println("파일 생성 시간: " + creationDateTime);
-
-            // 파일 생성 날짜가 오늘이고, 마감 시간을 넘겼을 경우에만 OCR 수행
-            if (IsInValidScreenShot(user_id, creationDateTime)) {
-                try {
-                    // 3. Google Vision API를 사용하여 OCR 수행
-                    List<String> extractedTexts = extractTextFromImage(filePath);
-
-                    // 커스텀 필터를 통해 필요한 텍스트만 추출
-                    Map<String, Object> filteredTexts = filterExtractedTexts(extractedTexts);
-
-                    // 해당 날짜에 설정해둔 목표 시간에 달성했을 때, 결과물을 담아서 보낸다.
-                    boolean screenTimeGoalResult = IsAchieveUsingTime(user_id, filteredTexts);
-
-                    // 현재 날짜
-                    LocalDate today = LocalDate.now();
-                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                    String todayToString = today.format(formatter);
-
-                    // OCR 결과 저장
-                    ScreenTimeOCRResult result = ScreenTimeOCRResult.builder()
-                            .user_id(user_id)
-                            .date(todayToString)
-                            .result(filteredTexts)
-                            .isSuccess(screenTimeGoalResult)
-                            .build();
-
-                    getScreenTimeOCRRepository.save(result);
-                    response.put("entity", filteredTexts);
-                    System.out.println("OCR 결과 저장 완료.");
-
-                } catch (Exception e) {
-                    DeleteFolderFiles(filePath);
-                    throw new CustomException(e.getMessage(), HttpStatus.BAD_REQUEST);
-                }
+            if(savedInstalledApps == null){
+                installedAppsRepository.save(newInstalledApps);
             } else {
-                DeleteFolderFiles(filePath);
-                throw new CustomException("파일 생성 시간이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+                installedAppsRepository.update(newInstalledApps);
             }
+            savedInstalledApps = newInstalledApps;
+        }
 
-            // 마지막에 임시 파일 삭제
-            DeleteFolderFiles(filePath);
-            return new ResponseEntity<>(response, HttpStatus.OK);
+        if(savedInstalledApps != null){
+            try {
+                // 1. 임시 파일로 저장
+                String filename = image.getOriginalFilename();
+                if (filename == null || filename.isEmpty()) {
+                    throw new CustomException("파일 이름이 비어 있습니다.", HttpStatus.BAD_REQUEST);
+                }
 
-        } catch (Exception e) {
-            throw new CustomException("파일 업로드 오류 발생: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+                Path tempDir = Files.createTempDirectory("upload");
+                System.out.println("Temporary directory created: " + tempDir);
+
+                Path filePath = tempDir.resolve(filename);
+                System.out.println("File will be saved at: " + filePath);
+
+                // 파일 저장
+                try {
+                    Files.write(filePath, image.getBytes());
+                    System.out.println("File written successfully to: " + filePath);
+                } catch (IOException e) {
+                    throw new CustomException("파일 저장 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+
+                // 2. 파일 생성 시간 확인(캡쳐 시간 확인)
+                BasicFileAttributes attr = Files.readAttributes(filePath, BasicFileAttributes.class);
+                FileTime creationTime = attr.creationTime();
+                LocalDateTime creationDateTime = creationTime
+                        .toInstant()
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime();
+
+                System.out.println("파일 생성 시간: " + creationDateTime);
+
+                // 파일 생성 날짜가 오늘이고, 마감 시간을 넘겼을 경우에만 OCR 수행
+                if (IsInValidScreenShot(user_id, creationDateTime)) {
+                    try {
+                        // 3. Google Vision API를 사용하여 OCR 수행
+                        List<String> extractedTexts = extractTextFromImage(filePath);
+
+                        // 커스텀 필터를 통해 필요한 텍스트만 추출
+                        Map<String, Object> filteredTexts = filterExtractedTexts(extractedTexts, savedInstalledApps.getInstalled_apps());
+
+                        // 해당 날짜에 설정해둔 목표 시간에 달성했을 때, 결과물을 담아서 보낸다.
+                        boolean screenTimeGoalResult = IsAchieveUsingTime(user_id, filteredTexts);
+
+                        // 현재 날짜
+                        LocalDate today = LocalDate.now();
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                        String todayToString = today.format(formatter);
+
+                        // OCR 결과 저장
+                        ScreenTimeOCRResult result = ScreenTimeOCRResult.builder()
+                                .user_id(user_id)
+                                .date(todayToString)
+                                .result(filteredTexts)
+                                .isSuccess(screenTimeGoalResult)
+                                .build();
+
+                        getScreenTimeOCRRepository.save(result);
+                        response.put("entity", filteredTexts);
+                        System.out.println("OCR 결과 저장 완료.");
+
+                    } catch (Exception e) {
+                        DeleteFolderFiles(filePath);
+                        throw new CustomException(e.getMessage(), HttpStatus.BAD_REQUEST);
+                    }
+                } else {
+                    DeleteFolderFiles(filePath);
+                    throw new CustomException("파일 생성 시간이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+                }
+
+                // 마지막에 임시 파일 삭제
+                DeleteFolderFiles(filePath);
+                return new ResponseEntity<>(response, HttpStatus.OK);
+
+            } catch (Exception e) {
+                System.out.print("Error: " + e.getMessage());
+                throw new CustomException("파일 업로드 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        }else{
+            throw new CustomException("설치된 앱 목록이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
         }
     }
 
@@ -256,7 +280,7 @@ public class ScreenTimeService {
         NONE, IOS, ANDROID,
     }
 
-    private Map<String, Object> filterExtractedTexts(List<String> extractedTexts){
+    private Map<String, Object> filterExtractedTexts(List<String> extractedTexts, List<String> savedInstalledApps){
         Map<String, Object> result = new HashMap<>();
         List<Map<String, String>> categories = new ArrayList<>();
 
@@ -265,10 +289,8 @@ public class ScreenTimeService {
         Pattern minutesPattern = Pattern.compile("(\\d+)분");
 
         boolean mainTimeCaptured = false;
-        AtomicInteger timeCount = new AtomicInteger(1);
-        List<String> categoryName = new ArrayList<>();
+        AtomicInteger timeCount = new AtomicInteger(0);
         boolean isCategory = false;
-        phoneType type = phoneType.NONE;
 
         for(String text : extractedTexts){
             // 날짜 추출
@@ -290,27 +312,13 @@ public class ScreenTimeService {
                 continue;
             }
 
-            if(text.equals("최다 사용") || text.equals("카테고리 보기")) {
+            if(text.equals("최다 사용") || text.equals("카테고리 보기") || text.equals("많이 사용한 앱")) {
                 isCategory = true;
-                type = phoneType.IOS;
-
-                continue;
-            } else if(text.equals("많이 사용한 앱")) {
-                isCategory = true;
-                type = phoneType.ANDROID;
-
                 continue;
             }
 
             if(mainTimeCaptured && isCategory){
-                switch (type){
-                    case IOS:
-                        getIphoneCategoriesInfo(timeCount, timePattern, minutesPattern, text, categories);
-                        break;
-                    case ANDROID:
-                        getAndroidCategoriesInfo(categoryName, timeCount, timePattern, minutesPattern, text, categories);
-                        break;
-                }
+                getCategoriesInfo(timeCount, timePattern, minutesPattern, text, categories, savedInstalledApps);
             }
         }
 
@@ -318,52 +326,35 @@ public class ScreenTimeService {
         return result;
     }
 
-    private void getIphoneCategoriesInfo(AtomicInteger timeCount, Pattern timePattern, Pattern minutesPattern, String text, List<Map<String, String>> categories){
-        if(timeCount.get() <= 3){
-            Matcher MatcherFullTime = timePattern.matcher(text);
-            Matcher MinMatcher = minutesPattern.matcher(text);
+    private void getCategoriesInfo(AtomicInteger timeCount, Pattern timePattern, Pattern minutesPattern, String text, List<Map<String, String>> categories, List<String> savedInstalledApps){
+        try{
+            if(timeCount.get() <= 3){
+                Matcher MatcherFullTime = timePattern.matcher(text);
+                Matcher MinMatcher = minutesPattern.matcher(text);
 
-            boolean fullTimeMatch = MatcherFullTime.matches();
-            boolean minMatch = MinMatcher.matches();
-            if(fullTimeMatch || minMatch){
-                String subtime = fullTimeMatch ? TimeFormatter(MatcherFullTime) : TimeFormatter(MinMatcher);
-                Map<String, String> categoryTime = categories.get(timeCount.get() - 1);
-                categoryTime.put("time", subtime);
+                boolean fullTimeMatch = MatcherFullTime.matches();
+                boolean minMatch = MinMatcher.matches();
+                if(fullTimeMatch || minMatch){
+                    String subTime = fullTimeMatch ? TimeFormatter(MatcherFullTime) : TimeFormatter(MinMatcher);
+                    Map<String, String> categoryTime = categories.get(timeCount.get() - 1);
+                    categoryTime.put("time", subTime);
 
-                timeCount.incrementAndGet();
-            }else{
-                if (text.length() > 1 && text.matches(".*[가-힣a-zA-Z0-9].*")) {
-                    Map<String, String> category = new HashMap<>();
-                    category.put("name", text);
-                    categories.add(category);
+                    timeCount.incrementAndGet();
+                }else{
+                    if (text.length() > 1 && text.matches(".*[가-힣a-zA-Z0-9].*")) {
+                        if(savedInstalledApps.contains(text)){
+                            Map<String, String> category = new HashMap<>();
+                            category.put("name", text);
+                            categories.add(category);
+                        }
+                    }
                 }
             }
+        }catch(Exception error){
+            System.out.println("Error: " + error.getMessage());
+            throw new CustomException("그래프 분석 중 오류가 발생하였습니다.", HttpStatus.BAD_REQUEST);
         }
-    }
 
-    private void getAndroidCategoriesInfo(List<String> categoryName, AtomicInteger timeCount, Pattern timePattern, Pattern minutesPattern, String text, List<Map<String, String>> categories){
-        if(timeCount.get() <= 3){
-            Matcher MatcherFullTime = timePattern.matcher(text);
-            Matcher MinMatcher = minutesPattern.matcher(text);
-
-            boolean fullTimeMatch = MatcherFullTime.matches();
-            boolean minMatch = MinMatcher.matches();
-            if(fullTimeMatch || minMatch){
-                Map<String, String> category = new HashMap<>();
-                category.put("name", categoryName.get(categoryName.size() - (4 - timeCount.get())));
-                categories.add(category);
-
-                String subtime = fullTimeMatch ? TimeFormatter(MatcherFullTime) : TimeFormatter(MinMatcher);
-                Map<String, String> categoryTime = categories.get(timeCount.get() - 1);
-                categoryTime.put("time", subtime);
-
-                timeCount.incrementAndGet();
-            }else{
-                if (text.length() > 1 && text.matches(".*[가-힣a-zA-Z0-9].*")) {
-                    categoryName.add(text);
-                }
-            }
-        }
     }
 
     private boolean IsInValidScreenShot(String user_id, LocalDateTime fileCreationDateTime) throws ExecutionException, InterruptedException {

--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -106,7 +106,7 @@ public class ScreenTimeService {
                     .installed_apps(installedApps).build();
 
             if(savedInstalledApps == null){
-                installedAppsRepository.save(newInstalledApps);
+                installedAppsRepository.saveWithAutoIncrement(newInstalledApps);
             } else {
                 installedAppsRepository.update(newInstalledApps);
             }
@@ -170,7 +170,7 @@ public class ScreenTimeService {
                                 .isSuccess(screenTimeGoalResult)
                                 .build();
 
-                        getScreenTimeOCRRepository.save(result);
+                        getScreenTimeOCRRepository.saveWithAutoIncrement(result);
                         response.put("entity", filteredTexts);
                         System.out.println("OCR 결과 저장 완료.");
 

--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -251,6 +252,10 @@ public class ScreenTimeService {
         }
     }
 
+    public enum phoneType {
+        NONE, IOS, ANDROID,
+    }
+
     private Map<String, Object> filterExtractedTexts(List<String> extractedTexts){
         Map<String, Object> result = new HashMap<>();
         List<Map<String, String>> categories = new ArrayList<>();
@@ -260,8 +265,10 @@ public class ScreenTimeService {
         Pattern minutesPattern = Pattern.compile("(\\d+)분");
 
         boolean mainTimeCaptured = false;
+        AtomicInteger timeCount = new AtomicInteger(1);
+        List<String> categoryName = new ArrayList<>();
         boolean isCategory = false;
-        int timeCount = 0;
+        phoneType type = phoneType.NONE;
 
         for(String text : extractedTexts){
             // 날짜 추출
@@ -278,35 +285,31 @@ public class ScreenTimeService {
                 result.put("mainTime", mainTime);
 
                 mainTimeCaptured = true;
-                timeCount++;
+                timeCount.incrementAndGet();
 
                 continue;
             }
 
-            if(text.equals("최다 사용") || text.equals("카테고리 보기") || text.equals("많이 사용한 앱")){
+            if(text.equals("최다 사용") || text.equals("카테고리 보기")) {
                 isCategory = true;
+                type = phoneType.IOS;
+
+                continue;
+            } else if(text.equals("많이 사용한 앱")) {
+                isCategory = true;
+                type = phoneType.ANDROID;
+
                 continue;
             }
 
-            //카테고리 및 각 카테고리별 시간 추출
-            if(mainTimeCaptured && timeCount <= 3 && isCategory){
-                Matcher MatcherFullTime = timePattern.matcher(text);
-                Matcher MinMatcher = minutesPattern.matcher(text);
-
-                boolean fullTimeMatch = MatcherFullTime.matches();
-                boolean minMatch = MinMatcher.matches();
-                if(fullTimeMatch || minMatch){
-                    String subtime = fullTimeMatch ? TimeFormatter(MatcherFullTime) : TimeFormatter(MinMatcher);
-                    Map<String, String> categoryTime = categories.get(timeCount - 1);
-                    categoryTime.put("time", subtime);
-
-                    timeCount++;
-                }else{
-                    if (text.length() > 1 && text.matches(".*[가-힣a-zA-Z0-9].*")) {
-                        Map<String, String> category = new HashMap<>();
-                        category.put("name", text);
-                        categories.add(category);
-                    }
+            if(mainTimeCaptured && isCategory){
+                switch (type){
+                    case IOS:
+                        getIphoneCategoriesInfo(timeCount, timePattern, minutesPattern, text, categories);
+                        break;
+                    case ANDROID:
+                        getAndroidCategoriesInfo(categoryName, timeCount, timePattern, minutesPattern, text, categories);
+                        break;
                 }
             }
         }
@@ -315,7 +318,53 @@ public class ScreenTimeService {
         return result;
     }
 
+    private void getIphoneCategoriesInfo(AtomicInteger timeCount, Pattern timePattern, Pattern minutesPattern, String text, List<Map<String, String>> categories){
+        if(timeCount.get() <= 3){
+            Matcher MatcherFullTime = timePattern.matcher(text);
+            Matcher MinMatcher = minutesPattern.matcher(text);
 
+            boolean fullTimeMatch = MatcherFullTime.matches();
+            boolean minMatch = MinMatcher.matches();
+            if(fullTimeMatch || minMatch){
+                String subtime = fullTimeMatch ? TimeFormatter(MatcherFullTime) : TimeFormatter(MinMatcher);
+                Map<String, String> categoryTime = categories.get(timeCount.get() - 1);
+                categoryTime.put("time", subtime);
+
+                timeCount.incrementAndGet();
+            }else{
+                if (text.length() > 1 && text.matches(".*[가-힣a-zA-Z0-9].*")) {
+                    Map<String, String> category = new HashMap<>();
+                    category.put("name", text);
+                    categories.add(category);
+                }
+            }
+        }
+    }
+
+    private void getAndroidCategoriesInfo(List<String> categoryName, AtomicInteger timeCount, Pattern timePattern, Pattern minutesPattern, String text, List<Map<String, String>> categories){
+        if(timeCount.get() <= 3){
+            Matcher MatcherFullTime = timePattern.matcher(text);
+            Matcher MinMatcher = minutesPattern.matcher(text);
+
+            boolean fullTimeMatch = MatcherFullTime.matches();
+            boolean minMatch = MinMatcher.matches();
+            if(fullTimeMatch || minMatch){
+                Map<String, String> category = new HashMap<>();
+                category.put("name", categoryName.get(categoryName.size() - (4 - timeCount.get())));
+                categories.add(category);
+
+                String subtime = fullTimeMatch ? TimeFormatter(MatcherFullTime) : TimeFormatter(MinMatcher);
+                Map<String, String> categoryTime = categories.get(timeCount.get() - 1);
+                categoryTime.put("time", subtime);
+
+                timeCount.incrementAndGet();
+            }else{
+                if (text.length() > 1 && text.matches(".*[가-힣a-zA-Z0-9].*")) {
+                    categoryName.add(text);
+                }
+            }
+        }
+    }
 
     private boolean IsInValidScreenShot(String user_id, LocalDateTime fileCreationDateTime) throws ExecutionException, InterruptedException {
         String fileCreationDate = fileCreationDateTime.toLocalDate().toString();

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
@@ -97,7 +97,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .password("")
                         .authority(UserRole.UNKNOWN) // UserRole 타입으로 직접 전달, 아직 권한 미지정
                         .build();
-                userRepository.save(user);
+                userRepository.saveWithAutoIncrement(user);
 
                 isNewUser = true; // 신규 회원
                 log.info("New user registered: {}, Random nickname: {}", user.getEmail(), randomNickname);


### PR DESCRIPTION
[Refact: [compose.yaml] 도커 컴포즈 볼륨 마운트 제거]
- github Action dockerfile에 fire-base.json을 생성하는 코드가 있음
- 근데 compose.yaml에 볼륨 마운트를 저렇게 해놓으면 로컬 파일로 다시 fire-base.json이 덮어쓰여지는 문제 발생 -> 수정

[Refact: [ScreenTimeController]
- AuthenticationPrincipal 정보 CustomOAuth2UserDetails로 linked_id 등 추가

[Refact: [build.gradle]]
- implementation 'io.grpc:grpc-protobuf-lite:1.62.2' 추가


[Feat: [InstalledApps] Entity 추가]
- 프론트로부터 설치된 앱 목록을 받아올 때 사용하는 entity

[Feat: [InstalledAppsRepository] Repository 추가]
- InstalledApps 파이어베이스 리포지토리 구현


[Refact: [ScreenTimeController] 사진 업로드 컨트롤러 수정]

- 프론트에서 폰에 설치된 앱 목록이 변경됐을 경우 넘어오는 앱 목록 값 파라미터 추가

[Refact: [ScreenTimeService] 업로드 받은 사진 텍스트 추출 로직 수정]
- 폰 타입 삭제
- 설치된 앱 목록에 포함되어있는 단어일 경우에만 카테고리 Map에 담기