### PR TITLE
Refact & Feat: 회원 탈퇴, 연동 아이디 관련 수정 및 추가

### DIFF
--- a/src/main/java/com/example/iplan/Repository/DefaultFirebaseRepository/DefaultFirebaseDBRepository.java
+++ b/src/main/java/com/example/iplan/Repository/DefaultFirebaseRepository/DefaultFirebaseDBRepository.java
@@ -4,6 +4,7 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.*;
 import com.google.cloud.firestore.annotation.DocumentId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +13,7 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
+@Slf4j
 @Component
 @Repository
 @RequiredArgsConstructor
@@ -153,6 +155,36 @@ public class DefaultFirebaseDBRepository<T> implements FirebaseDBRepository<T, S
         CollectionReference collection = firestore.collection(collectionName);
         ApiFuture<WriteResult> result = collection.document(getDocumentId(entity)).delete();
         result.get();
+    }
+
+    public void deleteAllByUserId(String userId) throws ExecutionException, InterruptedException {
+        CollectionReference collection = firestore.collection(collectionName);
+        QuerySnapshot querySnapshot = collection.whereEqualTo("user_id", userId).get().get();
+
+        if(querySnapshot.isEmpty()){
+            return;
+        }
+
+        WriteBatch batch = firestore.batch();
+        int cnt = 0;
+
+        for(DocumentSnapshot doc : querySnapshot.getDocuments()){
+            batch.delete(doc.getReference());
+            cnt++;
+
+            // Firestore WriteBatch는 최대 500건 제한
+            if(cnt == 500){
+                batch.commit().get(); // 실행하고
+                batch = firestore.batch(); // 새로운 배치 시작
+                cnt = 0;
+            }
+        }
+
+        if(cnt > 0){
+            batch.commit().get();
+        }
+
+        log.info("userId={}의 문서 {}건 삭제 완료", userId, querySnapshot.size());
     }
 
     /**

--- a/src/main/java/com/example/iplan/Service/AccountParentService.java
+++ b/src/main/java/com/example/iplan/Service/AccountParentService.java
@@ -141,6 +141,7 @@ public class AccountParentService {
                 );
                 JwtToken newToken = jwtTokenProvider.generateToken(authentication);
                 log.info("요청 승인됨.. 토큰 재발급 완료");
+                accountRepository.delete(accountRequest);
                 return ResponseEntity.ok(Map.of(
                         "success", true,
                         "status", "approved",
@@ -151,6 +152,8 @@ public class AccountParentService {
             // 2. 요청이 거부된 경우
             else if (accountRequest != null && !accountRequest.isApproved() && Objects.equals(accountRequest.getStatus(), "denied")) {
                 log.info("요청 거부됨");
+
+                accountRepository.delete(accountRequest);
                 return ResponseEntity.ok(Map.of(
                         "success", true,
                         "status", "denied",

--- a/src/main/java/com/example/iplan/auth/AuthController.java
+++ b/src/main/java/com/example/iplan/auth/AuthController.java
@@ -15,7 +15,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,12 +28,20 @@ public class AuthController {
     private final JwtProperties jwtProperties;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestHeader("Authorization") String authHeader) {
         String accessToken = authHeader.replace("Bearer ", "");
         jwtTokenProvider.destroyToken(accessToken);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/delete-account")
+    public ResponseEntity<?> deleteAccount(@RequestHeader("Authorization") String authHeader) throws ExecutionException, InterruptedException {
+        String accessToken = authHeader.replace("Bearer ", "");
+        userService.withdraw(accessToken); // 탈퇴 처리 서비스 호출
+        return ResponseEntity.ok(Map.of("message", "회원 탈퇴가 완료되었습니다."));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/example/iplan/auth/UserController.java
+++ b/src/main/java/com/example/iplan/auth/UserController.java
@@ -256,4 +256,20 @@ public class UserController {
         return new ResponseEntity<>(html, headers, HttpStatus.OK);
     }
 
+    @DeleteMapping("/my_page/delete/linked_id")
+    public ResponseEntity<?> deleteLinkedID(@AuthenticationPrincipal CustomOAuth2UserDetails userDetails, @RequestParam("linked_id") String linked_id){
+        log.info("연결된 계정: " + linked_id);
+
+        String email = userDetails.getEmail();
+        if(email != null){
+            userService.deleteLinkedId(email, linked_id);
+            return ResponseEntity.ok(Map.of(
+                    "message", "연결된 계정 삭제에 성공하였습니다."
+            ));
+        }else{
+            throw new CustomException("사용자의 이메일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+    }
+
 }

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -1,17 +1,21 @@
 package com.example.iplan.auth;
 
 import com.example.iplan.ExceptionHandler.CustomException;
+import com.example.iplan.Repository.FeedbackRepository;
+import com.example.iplan.Repository.PlanChildRepository;
+import com.example.iplan.Repository.RewardChildRepository;
 import com.example.iplan.auth.jwt.JwtProperties;
 import com.example.iplan.auth.jwt.JwtToken;
 import com.example.iplan.auth.jwt.JwtTokenProvider;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import com.example.iplan.auth.redis.RefreshTokenService;
+import com.google.api.client.util.Value;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -19,6 +23,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
@@ -31,7 +36,12 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class UserService {
     private final Firestore firestore;
+
     private final UserRepository userRepository;
+    private final PlanChildRepository planChildRepository;
+    private final RewardChildRepository rewardChildRepository;
+    private final FeedbackRepository feedbackRepository;
+
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
@@ -117,6 +127,126 @@ public class UserService {
         }
     }
 
+    public void withdraw(String accessToken) throws ExecutionException, InterruptedException {
+        String nickname = jwtTokenProvider.getUserNickname(accessToken);
+        Users user = userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        log.info("회원 탈퇴 사용자 id: {}", nickname);
+
+        // 1. 토큰 무효화
+        jwtTokenProvider.destroyToken(accessToken);
+
+        // 2. 연동 해제
+        for (String linkedId : user.getLinked_id()) {
+            deleteLinkedId(user.getEmail(), linkedId);
+        }
+
+        // 3. 소셜 연동 해제
+        if(user.getProvider() != null && user.getProviderAccessToken() != null){
+            try{
+                unlinkSocial(user.getProvider(), user.getProviderAccessToken());
+            }catch (Exception e){
+                log.warn("소셜 연동 해제 실패 : {}", e.getMessage());
+                throw new CustomException("소셜 연동 해제 실패", HttpStatus.BAD_REQUEST);
+            }
+            user.setProviderAccessToken(null); // 토큰 사용 후 파기
+        }
+
+        // 4. 관련 데이터 삭제 (계획, 보상 등)
+        planChildRepository.deleteAllByUserId(nickname);
+        rewardChildRepository.deleteAllByUserId(nickname);
+        feedbackRepository.deleteAllByUserId(nickname);
+        // 5. 사용자 문서 삭제
+        userRepository.delete(user);
+
+        log.info("회원 탈퇴 완료: {}", nickname);
+    }
+
+    public void unlinkSocial(String provider, String providerAccessToken){
+        if(providerAccessToken == null || providerAccessToken.isBlank()){
+            log.warn("소셜 연동 해제 생략: 토큰 없음");
+            return;
+        }
+
+        try{
+            switch (provider.toUpperCase()){
+                case "KAKAO":
+                    unlinkKakao(providerAccessToken);
+                    break;
+                case "NAVER":
+                    unlinkNaver(providerAccessToken);
+                    break;
+                case "GOOGLE":
+                    unlinkGoogle(providerAccessToken);
+                    break;
+                default:
+                    log.warn("지원하지 않는 소셜 provider입니다: {}", provider);
+            }
+        }catch(Exception e){
+            log.warn("{} 소셜 연동 해제 중 오류 발생: {}", provider, e.getMessage());
+            throw new CustomException("소셜 연동 해제 중 오류 발생", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void unlinkKakao(String accessToken){
+        String url = "https://kapi.kakao.com/v1/user/unlink";
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new RestTemplate().postForEntity(url, entity, String.class);
+
+        if(response.getStatusCode().is2xxSuccessful()){
+            log.info("카카오 연동 해제 성공");
+        }else{
+            log.warn("카카오 연도오 해제 실패 또는 이미 해제됨: {}", response.getBody());
+        }
+    }
+    private void unlinkGoogle(String accessToken) {
+        String url = "https://oauth2.googleapis.com/revoke?token=" + accessToken;
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new RestTemplate().postForEntity(url, entity, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            log.info("구글 연동 해제 성공");
+        } else {
+            log.warn("구글 연동 해제 실패 또는 이미 해제됨: {}", response.getBody());
+        }
+    }
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
+
+    private void unlinkNaver(String accessToken) {
+        String url = "https://nid.naver.com/oauth2.0/token" +
+                "?grant_type=delete" +
+                "&client_id=" + naverClientId +
+                "&client_secret=" + naverClientSecret +
+                "&access_token=" + accessToken +
+                "&service_provider=NAVER";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = new RestTemplate().postForEntity(url, entity, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            log.info("네이버 연동 해제 성공");
+        } else {
+            log.warn("네이버 연동 해제 실패 또는 이미 해제됨: {}", response.getBody());
+        }
+    }
+
+
     /**
      * 닉네임을 기반으로 사용자 조회
      */
@@ -195,6 +325,32 @@ public class UserService {
             }
         }
 
+    }
+
+    public void deleteLinkedId(String email, String linked_id){
+        try{
+            // 사용자의 연동된 계정을 삭제하고
+            Users user = findByEmail(email);
+
+            List<String> user_linked_id = user.getLinked_id();
+            user_linked_id.remove(linked_id);
+            user.setLinked_id(user_linked_id);
+
+            userRepository.update(user);
+
+            // 상대 연동 계정에서 나도 삭제한다.
+            Users linked_user = userRepository.findByNickname(linked_id)
+                    .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다: " + linked_id, HttpStatus.NOT_FOUND));
+
+            List<String> linked_user_linked_id = linked_user.getLinked_id();
+            linked_user_linked_id.remove(user.getNickname());
+            linked_user.setLinked_id(linked_user_linked_id);
+
+            userRepository.update(linked_user);
+
+        }catch (Exception e){
+            throw new CustomException("연동 아이디 제거 중 오류 발생: "+ e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
     }
 }
 

--- a/src/main/java/com/example/iplan/auth/Users.java
+++ b/src/main/java/com/example/iplan/auth/Users.java
@@ -44,4 +44,10 @@ public class Users {
 
     @Schema(description = "사용자 기기 토큰 값", example = "abc456")
     private String fcmToken = null;
+
+    @Schema(description = "어떤 소셜 플랫폼인지에 대한 정보", example = "google")
+    private String provider;
+
+    @Schema(description = "소셜 플랫폼에서 받은 access token")
+    private String providerAccessToken;
 }

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
@@ -42,6 +42,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String accessToken = userRequest.getAccessToken().getTokenValue();
 
         // 플랫폼별 사용자 정보 매핑
         // OAuth2UserInfo.of()를 호출하여 표준화된 사용자 정보로 변환
@@ -54,7 +55,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
 
         // 사용자 저장 또는 업데이트 -> user 설정(반환)
-        saveOrUpdate(oAuth2UserInfo);
+        saveOrUpdate(oAuth2UserInfo, registrationId, accessToken);
         if (user == null) {
             throw new RuntimeException("OAuth2 로그인 중 사용자 정보가 정상적으로 저장되지 않았습니다.");
         }
@@ -69,12 +70,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     /**
      * 디비에서 사용자 정보를 조회하고, 없으면 새로 저장
      */
-    private void saveOrUpdate(OAuth2UserInfo oAuth2UserInfo) {
+    private void saveOrUpdate(OAuth2UserInfo oAuth2UserInfo, String provider, String accessToken) {
         try {
             Optional<Users> existingUser = userRepository.findByEmail(oAuth2UserInfo.getEmail());
             if (existingUser.isPresent()) {
                 // 1. 기존 회원이 로그인하는 경우
                 user = existingUser.get();
+                user.setProvider(provider);
+                user.setProviderAccessToken(accessToken);
+                userRepository.update(user);
                 isNewUser = false; // 기존 회원
                 log.info("User already exists: {}", user.getEmail());
             } else {
@@ -90,6 +94,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .password("")
                         .authority(UserRole.UNKNOWN) // UserRole 타입으로 직접 전달, 아직 권한 미지정
                         .linked_id(new ArrayList<>()) // 빈 리스트로 초기화
+                        .provider(provider)
+                        .providerAccessToken(accessToken)
                         .build();
                 userRepository.saveWithAutoIncrement(user);
 


### PR DESCRIPTION
[Refact] AccountParentService: 아이디 연동 요청 승인 or 거부시 요청 데이터 PendingAccountRequest 제거하기

[Feat] AuthController: 회원 탈퇴 기능 구현 (/delete-account) 

[Refact] 
1. CustomOAuth2UserService: 탈퇴시 소셜 로그인 연동 해제를 위해 필요한 accessToken을 소셜 인증 이후 loadUser() 할 때 Users 설정에 넣어주기
2. Users: 마찬가지로 해당 데이터를 담을 provider, providerAccessToken을 만들어줌

[Feat] DefaultFirebaseDBRepository: 탈퇴시 유저의 모든 데이터를 삭제하기 위한 deleteAllByUserId() 구현 

[Feat] UserController: 연동된 아이디를 삭제하는 기능 구현(/my_page/delete/linked_id)

[Feat] UserService: 
1. 회원 탈퇴 withdraw 구현
- 토큰 무효화, 연동 아이디 해제, 소셜 연동 해제, 관련 데이터 삭제, 사용사 문서 삭제
- 각 소셜별 연동 해제 메서드
2. 연동된 계정 삭제 deleteLinkedId 구현
- 상대 연동 계정에서 나도 삭제한다.