### PR TITLE
프론트에서의 실시간 데이터 변경 감지(onSnapshot())를 위한 로직 추가

### DIFF
--- a/src/main/java/com/example/iplan/Controller/FeedbackController.java
+++ b/src/main/java/com/example/iplan/Controller/FeedbackController.java
@@ -7,6 +7,7 @@ import com.example.iplan.Domain.RewardParents;
 import com.example.iplan.Service.FeedbackService;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import com.google.firebase.database.annotations.NotNull;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -45,6 +46,23 @@ public class FeedbackController {
         return feedbackService.updateFeedback(feedbackDTO, parentNickname);
     }
 
+    // 부모의 linked_id를 기반으로 모든 자녀의 전체 피드백 목록 반환
+    @Operation(summary = "부모의 자녀 전체 피드백 목록 조회 GET", description = "해당 부모와 연동된 모든 자녀의 피드백 목록을 가져온다.")
+    @GetMapping("/parent/feedback/list")
+    public ResponseEntity<Map<String, Object>> getAllFeedbackList(
+            @AuthenticationPrincipal CustomOAuth2UserDetails user) throws ExecutionException, InterruptedException {
+
+        String parentNickname = user.getUsername();
+        List<String> linkedIds = user.getUser().getLinked_id();
+
+        // 예외 처리: 연동된 자녀가 없는 경우
+        if (linkedIds == null || linkedIds.isEmpty()) {
+            return new ResponseEntity<>(Map.of("success", false, "message", "연동된 자녀가 없습니다."), HttpStatus.BAD_REQUEST);
+        }
+
+        return feedbackService.getAllFeedbacks(parentNickname);
+    }
+
     // 부모가 해당하는 아이에 대한 모든 피드백 가져옴 (child, parent 요청 모두 가능)
     @GetMapping("/feedback/list/{childNickname}")
     public ResponseEntity<Map<String, Object>> getFeedbackParents(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String childNickname)
@@ -69,7 +87,18 @@ public class FeedbackController {
             parentNickname = user.getUsername();
         }
         log.info("부모 아이디: {}", parentNickname);
-        Map<String, Object> response = feedbackService.getFeedbackParents(childNickname, parentNickname);
+        Map<String, Object> response = feedbackService.getOneChildFeedback(childNickname, parentNickname);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 단일 피드백 목록 반환 -> 프론트에서 onSnapshot()으로 데이터 변경 감지 후 바뀐 피드백만 가져오는것
+    // 아이가 요청하는 경우만 해당
+    @Operation(summary = "onSnapshot()으로 감지한 바뀐 피드백 데이터 GET", description = "단일 피드백 목록을 가져온다.")
+    @GetMapping("/feedback/changed")
+    public ResponseEntity<Map<String, Object>> getChangedFeedback(@AuthenticationPrincipal CustomOAuth2UserDetails user, @RequestParam("feedbackId") String feedbackId) throws ExecutionException, InterruptedException {
+        String childNickname = user.getUsername();
+        log.info("변경된 피드백 ID: {}", feedbackId);
+        Map<String, Object> response = feedbackService.getFeedbackById(childNickname, feedbackId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/iplan/Controller/PlanParentController.java
+++ b/src/main/java/com/example/iplan/Controller/PlanParentController.java
@@ -74,4 +74,20 @@ public class PlanParentController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    /**
+     * 아이의 단일 계획 목록 반환
+     * -> 프론트에서 onSnapshot()으로 데이터 변경 감지 후 바뀐 계획만 가져오는것
+     */
+    @Operation(summary = "onSnapshot()으로 감지한 바뀐 계획 데이터 GET", description = "해당 사용자의 단일 계획 목록을 가져온다.")
+    @GetMapping("/changed")
+    public ResponseEntity<Map<String, Object>> getUpdatedPlan(
+            @AuthenticationPrincipal CustomOAuth2UserDetails user,
+            @RequestParam("planId") String planId,
+            @RequestParam("selectedChild") String childNickname) throws ExecutionException, InterruptedException {
+
+        log.info("변경된 계획 ID: {}", planId);
+        Map<String, Object> response = planParentService.getPlanById(childNickname, planId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/iplan/Controller/RewardChildController.java
+++ b/src/main/java/com/example/iplan/Controller/RewardChildController.java
@@ -53,20 +53,16 @@ public class RewardChildController {
     }
 
     /**
-     * 보상 세부사항을 가져옴
-     * @param documentId 보상 ID
-     * @return 보상 객체
-     * @throws ExecutionException
-     * @throws InterruptedException
+     * 사용자의 단일 보상 목록 반환
+     * -> 프론트에서 onSnapshot()으로 데이터 변경 감지 후 바뀐 보상만 가져오는것
      */
-    @Operation(summary = "보상 엔티티 GET", description = "해당 ID의 보상 엔티티를 가져온다.",
-            parameters = {
-                    @Parameter(name = "documentID", description = "해당 보상 문서 Id", example = "xicv3412zz", required = true)
-            })
-    @GetMapping("/{documentId}")
-    public ResponseEntity<RewardChild> getReward(@PathVariable @Parameter(example = "sdfg123") String documentId) throws ExecutionException, InterruptedException {
-        RewardChild reward = rewardChildService.getReward(documentId);
-        return ResponseEntity.ok(reward);
+    @Operation(summary = "onSnapshot()으로 감지한 바뀐 보상 데이터 GET", description = "해당 사용자의 단일 보상 목록을 가져온다.")
+    @GetMapping("/changed")
+    public ResponseEntity<Map<String, Object>> getChangedReward(@AuthenticationPrincipal CustomOAuth2UserDetails user, @RequestParam("rewardId") String rewardId) throws ExecutionException, InterruptedException {
+        String nickname = user.getUsername();
+        log.info("변경된 보상 ID: {}", rewardId);
+        Map<String, Object> response = rewardChildService.getRewardById(nickname, rewardId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/com/example/iplan/Controller/RewardParentsController.java
+++ b/src/main/java/com/example/iplan/Controller/RewardParentsController.java
@@ -6,6 +6,7 @@ import com.example.iplan.Service.RewardParentsService;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/parent/reward")
@@ -38,6 +40,21 @@ public class RewardParentsController {
         }
 
         Map<String, Object> response = rewardParentsService.getRewardsForAllChildren(linkedIds);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * 사용자의 단일 보상 목록 반환
+     * -> 프론트에서 onSnapshot()으로 데이터 변경 감지 후 바뀐 보상만 가져오는것
+     */
+    @Operation(summary = "onSnapshot()으로 감지한 바뀐 보상 데이터 GET", description = "해당 사용자의 단일 보상 목록을 가져온다.")
+    @GetMapping("/changed")
+    public ResponseEntity<Map<String, Object>> getUpdatedReward(
+            @AuthenticationPrincipal CustomOAuth2UserDetails user,
+            @RequestParam("rewardId") String rewardId,
+            @RequestParam("childNickname") String childNickname) throws ExecutionException, InterruptedException {
+
+        Map<String, Object> response = rewardParentsService.getRewardById(childNickname, rewardId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/example/iplan/Domain/PlanChild.java
+++ b/src/main/java/com/example/iplan/Domain/PlanChild.java
@@ -22,9 +22,8 @@ public class PlanChild {
     @Schema(description = "계획 데이터 고유 ID", example = "12345")
     private String id; // Firestore 문서의 ID
 
-    //User 테이블의 아이디
     @NotNull
-    @Schema(description = "사용자 UID", example = "user123")
+    @Schema(description = "사용자 닉네임", example = "user123")
     private String user_id;
 
     @NotNull

--- a/src/main/java/com/example/iplan/Repository/FeedbackRepository.java
+++ b/src/main/java/com/example/iplan/Repository/FeedbackRepository.java
@@ -1,12 +1,14 @@
 package com.example.iplan.Repository;
 
+import com.example.iplan.DTO.FeedbackDTO;
 import com.example.iplan.Domain.Feedback;
+import com.example.iplan.Domain.RewardChild;
+import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.DefaultFirebaseRepository.DefaultFirebaseDBRepository;
 import com.google.api.core.ApiFuture;
-import com.google.cloud.firestore.CollectionReference;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.QueryDocumentSnapshot;
-import com.google.cloud.firestore.QuerySnapshot;
+import com.google.cloud.firestore.*;
+import com.google.firebase.cloud.FirestoreClient;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -15,54 +17,73 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 @Repository
-public class FeedbackRepository extends DefaultFirebaseDBRepository<Feedback>  {
+public class FeedbackRepository extends DefaultFirebaseDBRepository<Feedback> {
 
     public FeedbackRepository(Firestore firestore) {
         super(firestore);
         setEntityClass(Feedback.class);
-        setCollectionName("Feedback"); // Firestore에서 저장할 컬렉션 이름 설정
+        setCollectionName("Feedback");
     }
 
     /**
-     * 특정 사용자 ID와 일치하는 보상 부모 목록을 반환
+     * 특정 사용자 ID와 일치하는 피드백 목록을 DTO 형태로 반환
      */
-    public List<Feedback> findRewardParentsListByUserId(String userId) throws ExecutionException, InterruptedException {
-        CollectionReference collection = firestore.collection("Feedback");
-
-        ApiFuture<QuerySnapshot> apiFutureList = collection
-                .whereEqualTo("user_id", userId)  // 필드 이름을 정확히 설정해야 함
-                .get();
-
-        QuerySnapshot querySnapshot = apiFutureList.get();
-
-        List<Feedback> rewardParents = new ArrayList<>();
-
-        for (QueryDocumentSnapshot document : querySnapshot.getDocuments()) {
-            rewardParents.add(document.toObject(Feedback.class));
-        }
-
-        return rewardParents;
+    public List<Feedback> findFeedbackDtoByUserId(String userId) throws ExecutionException, InterruptedException {
+        return findAllByField("user_id", userId);
     }
 
     /**
-     * 특정 보상 ID와 일치하는 보상 목록을 반환
+     * 특정 보상 ID와 사용자 ID에 일치하는 피드백 목록 반환
      */
-    public List<Feedback> findByRewardId(String user_id, String reward_id) throws ExecutionException, InterruptedException {
-        Map<String, Object> filters = Map.of(
-                "user_id", user_id,
-                "reward_id", reward_id
-        );
-        return findAllByFields(filters);
+    public List<Feedback> findByRewardId(String userId, String rewardId) throws ExecutionException, InterruptedException {
+        return findAllByFields(Map.of(
+                "user_id", userId,
+                "reward_id", rewardId
+        ));
     }
 
     /**
-     * 특정 보상 ID와 일치하는 보상 목록을 반환
+     * 특정 부모 닉네임(user_id)과 자녀 닉네임(child_id)에 해당하는 피드백 목록 반환
      */
     public List<Feedback> findByUserIdChildId(String parentNickname, String childNickname) throws ExecutionException, InterruptedException {
-        Map<String, Object> filters = Map.of(
+        return findAllByFields(Map.of(
                 "user_id", parentNickname,
                 "child_id", childNickname
-        );
-        return findAllByFields(filters);
+        ));
+    }
+
+    /**
+     * Feedback ID로 해당하는 문서 반환
+     */
+    public Feedback findFeedbackByID(String feedbackId) throws ExecutionException, InterruptedException {
+        Feedback feedback = findEntityByDocumentId(feedbackId);
+        if (feedback == null) {
+            throw new CustomException("해당 ID의 Feedback 문서가 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        return feedback;
+    }
+
+    /**
+     * Feedback 리스트를 FeedbackDTO 리스트로 변환
+     */
+    private List<FeedbackDTO> convertToDTOList(List<Feedback> feedbackList) {
+        List<FeedbackDTO> feedbackDTOList = new ArrayList<>();
+        for (Feedback feedback : feedbackList) {
+            feedbackDTOList.add(convertToDTO(feedback));
+        }
+        return feedbackDTOList;
+    }
+
+    /**
+     * Feedback 엔티티를 FeedbackDTO로 변환
+     */
+    private FeedbackDTO convertToDTO(Feedback feedback) {
+        return FeedbackDTO.builder()
+                .reward_id(feedback.getReward_id())
+                .child_id(feedback.getChild_id())
+                .comment(feedback.getComment())
+                .grade(feedback.getGrade())
+                .success(feedback.isSuccess())
+                .build();
     }
 }

--- a/src/main/java/com/example/iplan/Repository/RewardChildRepository.java
+++ b/src/main/java/com/example/iplan/Repository/RewardChildRepository.java
@@ -1,7 +1,9 @@
 package com.example.iplan.Repository;
 
+import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.DTO.RewardChildDTO;
+import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.DefaultFirebaseRepository.DefaultFirebaseDBRepository;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
@@ -9,6 +11,7 @@ import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.firebase.cloud.FirestoreClient;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -43,6 +46,17 @@ public class RewardChildRepository extends DefaultFirebaseDBRepository<RewardChi
         QuerySnapshot querySnapshot = apiFutureList.get();
 
         return getRewardChildDTOS(querySnapshot);
+    }
+
+    /**
+     * Reward ID로 해당하는 문서 반환
+     */
+    public RewardChild findRewardByID(String planId) throws ExecutionException, InterruptedException {
+        RewardChild rewardChild = findEntityByDocumentId(planId);
+        if (rewardChild == null) {
+            throw new CustomException("해당 ID의 PlanChild 문서가 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        return rewardChild;
     }
 
     /**

--- a/src/main/java/com/example/iplan/Service/FeedbackService.java
+++ b/src/main/java/com/example/iplan/Service/FeedbackService.java
@@ -1,14 +1,12 @@
 package com.example.iplan.Service;
 
-import com.example.iplan.DTO.RewardChildDTO;
 import com.example.iplan.DTO.FeedbackDTO;
 import com.example.iplan.Domain.Feedback;
-import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.Domain.RewardChild;
-import com.example.iplan.Domain.RewardParents;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.FeedbackRepository;
 import com.example.iplan.Repository.RewardChildRepository;
+import com.example.iplan.auth.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -24,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
     private final RewardChildRepository rewardChildRepository;
+    private final UserRepository userRepository;
 
     /**
      * 부모님의 보상 코멘트와 별점, 보상 지급 여부를 저장하는 기능
@@ -75,9 +74,36 @@ public class FeedbackService {
     }
 
     /**
+     * 부모의 모든 피드백 목록 반환
+     */
+    public ResponseEntity<Map<String, Object>> getAllFeedbacks(String parentNickname) throws ExecutionException, InterruptedException {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            // 사용자의 모든 피드백을 가져오기
+            List<Feedback> feedbacks = feedbackRepository.findFeedbackDtoByUserId(parentNickname);
+
+            if (feedbacks.isEmpty()) {
+                response.put("success", false);
+                response.put("message", "피드백 목록이 존재하지 않습니다.");
+                log.info("피드백 목록이 존재하지 않습니다.: {}", parentNickname);
+            } else {
+                response.put("success", true);
+                response.put("feedbacks", feedbacks);
+                log.info("{}'s feedbacks received successfully!! Size: {}", parentNickname, feedbacks.size());
+            }
+
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Error of {}: {}", parentNickname, e.getMessage());
+            throw new ExecutionException("보상 목록을 가져오는 중 오류가 발생했습니다.", e);
+        }
+    }
+
+
+    /**
      * 부모의 해당 아이에 대한 모든 코멘트와 별점을 조회하는 기능
      */
-    public Map<String, Object> getFeedbackParents(String childNickname, String parentNickname) throws ExecutionException, InterruptedException {
+    public Map<String, Object> getOneChildFeedback(String childNickname, String parentNickname) throws ExecutionException, InterruptedException {
         Map<String, Object> response = new HashMap<>();
         try {
             List<Feedback> feedbacks = feedbackRepository.findByUserIdChildId(parentNickname, childNickname);
@@ -159,5 +185,28 @@ public class FeedbackService {
             throw new CustomException("수정에 실패했습니다. Error: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    /**
+     * 단일 피드백 반환
+     */
+    public Map<String, Object> getFeedbackById(String childNickname, String feedbackId) throws ExecutionException, InterruptedException {
+        // feedbackId에 해당하는 계획 가져오기
+        Feedback feedback = feedbackRepository.findFeedbackByID(feedbackId);
+
+        try {
+            if (feedback != null) {
+                // 피드백의 user_id와 인증객체 유저와 일치한지 확인
+                if (!Objects.equals(feedback.getChild_id(), childNickname)) {
+                    throw new CustomException("해당 피드백에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                }
+                return Map.of("success", true, "message", feedbackId + " 피드백 반환 성공", "feedback", feedback);
+            } else {
+                throw new CustomException(feedbackId + " ID의 피드백이 존재하지 않음", HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
+            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
 
 }

--- a/src/main/java/com/example/iplan/Service/PlanParentService.java
+++ b/src/main/java/com/example/iplan/Service/PlanParentService.java
@@ -1,15 +1,14 @@
 package com.example.iplan.Service;
 
 import com.example.iplan.Domain.PlanChild;
+import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.PlanChildRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
@@ -58,6 +57,30 @@ public class PlanParentService {
         }
         log.info("Get plan for {} successfully!", childNickname);
         return response;
+    }
+
+    /**
+     * 아이의 단일 계획 반환 -> onSnapshot() 감지로 인한 해당 계획의 데이터 반환
+     */
+    public Map<String, Object> getPlanById(String childNickname, String planId) throws ExecutionException, InterruptedException {
+        // planId에 해당하는 계획 가져오기
+        PlanChild plan = planChildRepository.findPlanByID(planId);
+
+        try {
+            if (plan != null) {
+                // 계획의 user_id와 일치한지 확인
+                if (!Objects.equals(plan.getUser_id(), childNickname)) {
+                    throw new CustomException("해당 계획에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                }
+                return Map.of("success", true, "message", planId + " 계획 반환 성공", "plan", plan);
+            } else {
+                throw new CustomException(planId + " ID의 계획이 존재하지 않음", HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
+            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+
     }
 
 }

--- a/src/main/java/com/example/iplan/Service/RewardChildService.java
+++ b/src/main/java/com/example/iplan/Service/RewardChildService.java
@@ -1,6 +1,7 @@
 package com.example.iplan.Service;
 
 import com.example.iplan.DTO.RewardChildDTO;
+import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.RewardChildRepository;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
@@ -63,17 +65,24 @@ public class RewardChildService {
     }
 
     /**
-     * 보상을 ID로 조회하는 기능
-     * @param id 검색할 보상의 ID
-     * @return 검색된 보상 객체
-     * @throws ExecutionException
-     * @throws InterruptedException
+     * 사용자의 단일 보상 반환 -> onSnapshot() 감지로 인한 해당 보상의 데이터 반환
      */
-    public RewardChild getReward(String id) throws ExecutionException, InterruptedException {
+    public Map<String, Object> getRewardById(String childNickname, String rewardId) throws ExecutionException, InterruptedException {
+        // rewardId에 해당하는 계획 가져오기
+        RewardChild reward = rewardChildRepository.findRewardByID(rewardId);
+
         try {
-            return rewardChildRepository.findEntityByDocumentId(id);
+            if (reward != null) {
+                // 보상의 user_id와 인증객체 유저와 일치한지 확인
+                if (!Objects.equals(reward.getUser_id(), childNickname)) {
+                    throw new CustomException("해당 보상에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                }
+                return Map.of("success", true, "message", rewardId + " 보상 반환 성공", "reward", reward);
+            } else {
+                throw new CustomException(rewardId + " ID의 보상이 존재하지 않음", HttpStatus.NOT_FOUND);
+            }
         } catch (Exception e) {
-            throw new ExecutionException("보상 조회에 실패했습니다. Error: " + e, e);
+            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/example/iplan/Service/RewardParentsService.java
+++ b/src/main/java/com/example/iplan/Service/RewardParentsService.java
@@ -1,6 +1,8 @@
 package com.example.iplan.Service;
 
 import com.example.iplan.DTO.RewardChildDTO;
+import com.example.iplan.Domain.PlanChild;
+import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.RewardChildRepository;
 import com.example.iplan.auth.UserRepository;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
@@ -65,6 +68,30 @@ public class RewardParentsService {
             log.error("Error while getting rewards for {}: {}", nickname, e.getMessage());
             throw new ExecutionException("보상 조회 중 오류 발생", e);
         }
+    }
+
+    /**
+     * 한 자녀의 단일 보상 반환 -> onSnapshot() 감지로 인한 해당 계획의 데이터 반환
+     */
+    public Map<String, Object> getRewardById(String childNickname, String rewardId) throws ExecutionException, InterruptedException {
+        // planId에 해당하는 계획 가져오기
+        RewardChild reward = rewardChildRepository.findRewardByID(rewardId);
+
+        try {
+            if (reward != null) {
+                // 보상의 user_id와 인증객체 유저와 일치한지 확인
+                if (!Objects.equals(reward.getUser_id(), childNickname)) {
+                    throw new CustomException("해당 보상에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                }
+                return Map.of("success", true, "message", rewardId + " 보상 반환 성공", "reward", reward);
+            } else {
+                throw new CustomException(rewardId + " ID의 보상이 존재하지 않음", HttpStatus.NOT_FOUND);
+            }
+        } catch (Exception e) {
+            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+
     }
 
 }

--- a/src/main/java/com/example/iplan/auth/AuthController.java
+++ b/src/main/java/com/example/iplan/auth/AuthController.java
@@ -32,13 +32,14 @@ public class AuthController {
     private final UserService userService;
 
     @DeleteMapping("/delete-account")
-    public ResponseEntity<?> deleteAccount(@RequestHeader("Authorization") String authHeader,
+    public ResponseEntity<String> deleteAccount(@RequestHeader("Authorization") String authHeader,
                                            @RequestHeader("fcm-token") String fcmToken,
                                            @AuthenticationPrincipal CustomOAuth2UserDetails customOAuth2UserDetails) throws ExecutionException, InterruptedException {
         String accessToken = authHeader.replace("Bearer ", "");
         String userId = customOAuth2UserDetails.getUsername();
-        userService.withdraw(accessToken, fcmToken, userId); // 탈퇴 처리 서비스 호출
-        return ResponseEntity.ok(Map.of("message", "회원 탈퇴가 완료되었습니다."));
+        String uid = customOAuth2UserDetails.getFirebaseAuthUID();
+        String result = userService.withdraw(accessToken, fcmToken, userId, uid); // 탈퇴 처리 서비스 호출
+        return ResponseEntity.ok(result);
     }
 
     @PostMapping("/auth/refresh")

--- a/src/main/java/com/example/iplan/auth/UserController.java
+++ b/src/main/java/com/example/iplan/auth/UserController.java
@@ -8,6 +8,7 @@ import com.example.iplan.auth.jwt.JwtToken;
 import com.example.iplan.auth.jwt.JwtTokenProvider;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.UserRecord;
 import com.google.firebase.auth.FirebaseToken;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,6 @@ public class UserController {
 
             // firebase ID 토큰 검증
             FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdToken(idToken);
-
             if (!decodedToken.isEmailVerified()) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("이메일 본인인증이 완료되지 않았습니다.");
             }
@@ -56,10 +56,8 @@ public class UserController {
             String password = signUpDto.getPassword();
             String name = signUpDto.getName();
             String authority = signUpDto.getAuthority();
-            log.info("Register request: nickname = {}, password = {}, name = {}, email = {}, authority: {}", nickname, password, name, verifiedEmail, authority);
 
             String result = userService.signUp(nickname, password, name, verifiedEmail, authority);
-            log.info("Register result: {}", result);
 
             return ResponseEntity.ok(result);
 
@@ -83,6 +81,16 @@ public class UserController {
         return jwtToken;
     }
 
+    @GetMapping("/firebase/custom-token")
+    @Operation(summary = "Firebase Custom Token 생성")
+    public ResponseEntity<Map<String, String>> generateFirebaseToken(@AuthenticationPrincipal CustomOAuth2UserDetails userDetails) throws FirebaseAuthException {
+        String nickname = userDetails.getUsername();
+        Users user = userService.findByNickname(nickname);
+
+        String customToken = FirebaseAuth.getInstance().createCustomToken(user.getFirebaseAuthUID());
+        log.info("Custom Token: {}", customToken);
+        return ResponseEntity.ok(Map.of("customToken", customToken));
+    }
 
     @PostMapping("/auth/check-nickname")
     @Operation(summary = "중복 아이디 체크")
@@ -129,6 +137,7 @@ public class UserController {
         userInfo.put("name", user.getName());
         userInfo.put("authority", user.getAuthority().name());
         userInfo.put("linked_id", user.getLinked_id() != null ? user.getLinked_id() : ""); // null 방지
+        userInfo.put("uid", user.getFirebaseAuthUID() != null ? user.getFirebaseAuthUID() : "");
 
         log.info("Received user info: {}", userInfo);
         return ResponseEntity.ok(userInfo);
@@ -140,47 +149,51 @@ public class UserController {
     @PostMapping("/unknown/update-role")
     public ResponseEntity<Map<String, String>> updateUserRole(@AuthenticationPrincipal CustomOAuth2UserDetails userDetails, @RequestBody Map<String, String> requestBody) {
 
-        log.info("Update user role by nickname..");
         String nickname = userDetails.getUsername();
-        if (nickname == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Unauthorized"));
-        }
 
-        String roleStr = requestBody.get("role"); // 요청에서 역할 가져오기
+        String roleStr = requestBody.get("role");
         if (roleStr == null || (!roleStr.equals("ROLE_CHILD") && !roleStr.equals("ROLE_PARENT"))) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", "Invalid role"));
+            throw new CustomException("사용자 역할이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
 
-        userService.updateUserRole(nickname, roleStr); // 사용자 역할 업데이트
+        // 사용자 역할 업데이트
+        userService.updateUserRole(nickname, roleStr);
         log.info("Nickname: {}, Role: {}", nickname, roleStr);
 
-        // SecurityContext에서 올바른 Authentication을 생성하여 JWT를 발급해야함
-        // 따라서 1. DB에서 사용자 객체 조회 2. 정확한 권한을 포함한 Authentication 객체 생성 후 새로운 토큰을 발급
+        // SecurityContext 에서 올바른 Authentication(인증객체)을 생성하여 JWT 를 발급해야함
+        // 따라서 1) DB 에서 사용자 객체 조회 2)정확한 권한을 포함한 Authentication 객체 생성 후 새로운 토큰을 발급
 
-        // 1. 사용자 객체를 다시 조회 (업데이트된 역할 포함)
+        // 1. 사용자 객체를 다시 조회 (업데이트된 정보 포함)
         Users updatedUser = userService.findByNickname(nickname);
         log.info("Updated user info: {}", updatedUser);
-        if (updatedUser == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "User not found"));
-        }
 
-        // 2. CustomOAuth2UserDetails 객체를 생성
-        CustomOAuth2UserDetails newUserDetails = new CustomOAuth2UserDetails(updatedUser);
-
-        // 이 객체를 이용해 UsernamePasswordAuthenticationToken 기반의 Authentication 객체 생성
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-                newUserDetails, null, newUserDetails.getAuthorities()
-        );
+        // 2. 인증객체 생성
+        Authentication authentication = getAuthentication(updatedUser);
 
         // 3. 새로운 JWT 토큰 발급
         JwtToken newToken = jwtTokenProvider.generateToken(authentication);
-        log.info("새로운 JWT 토큰 발급 완료 - AccessToken: {}", newToken.getAccessToken());
+        log.info("새로운 JWT 토큰 발급 완료 - AccessToken: {}, RefreshToken: {}", newToken.getAccessToken(), newToken.getRefreshToken());
 
         // 새로운 JWT 토큰 반환
         return ResponseEntity.ok(Map.of(
                 "message", "Role updated successfully",
-                "accessToken", newToken.getAccessToken()
+                "accessToken", newToken.getAccessToken(),
+                "refreshToken", newToken.getRefreshToken()
         ));
+    }
+
+    private static Authentication getAuthentication(Users updatedUser) {
+        if (updatedUser == null) {
+            throw new CustomException("사용자가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        // 추가 정보가 반영된 유저로 CustomOAuth2UserDetails 객체 생성
+        CustomOAuth2UserDetails newUserDetails = new CustomOAuth2UserDetails(updatedUser);
+
+        // 이 객체를 이용해 UsernamePasswordAuthenticationToken 기반의 Authentication 객체 생성
+        return new UsernamePasswordAuthenticationToken(
+                newUserDetails, null, newUserDetails.getAuthorities()
+        );
     }
 
     /**

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -19,6 +19,9 @@ import com.google.api.client.util.Value;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.UserRecord;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -67,9 +70,10 @@ public class UserService {
                 throw new IllegalArgumentException("Nickname already exists.");
             }
 
-            UserRole role = UserRole.fromString(roleStr);   // Enum 변환
+            // 2. authority Enum 변환
+            UserRole role = UserRole.fromString(roleStr);
 
-            // 2. Users 객체 생성
+            // 3. Users 객체 생성
             Users user = Users.builder()
                     .nickname(nickname)
                     .email(email)
@@ -77,10 +81,12 @@ public class UserService {
                     .name(name)
                     .authority(role)    // child, parent
                     .linked_id(new ArrayList<>()) // 빈 리스트로 초기화
+                    .firebaseAuthUID("")
                     .build();
 
-            // 3. 사용자 정보 User 컬렉션에 저장 -> 자동 증가된 ID로 저장
+            // 4. 사용자 정보 User 컬렉션에 저장 -> 자동 증가된 ID로 저장
             userRepository.saveWithAutoIncrement(user);
+            log.info("회원가입 성공");
 
             return "Sign Up Successfully";
         } catch (ExecutionException | InterruptedException e) {
@@ -109,23 +115,53 @@ public class UserService {
             // 3. 사용자 인증 이후 Authentication 객체를 SecurityContextHolder 에 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            // 인증된 사용자 조회
+            // 4. 사용자 정보 조회
             Users user = userRepository.findByNickname(nickname)
-                    .orElseThrow(() -> new IllegalArgumentException("User not found."));
+                    .orElseThrow(() -> new CustomException("사용자 없음", HttpStatus.NOT_FOUND));
 
-            // 4. fcmToken 디비에 업데이트
+            // 5. Firebase 사용자 생성 및 UID 저장
+            if (user.getFirebaseAuthUID() == null || user.getFirebaseAuthUID().isBlank()) {
+                UserRecord userRecord;
+                try {
+                    try {
+                        // 이메일로 이미 존재하는지 확인
+                        userRecord = FirebaseAuth.getInstance().getUserByEmail(user.getEmail());
+                        log.info("기존 Firebase Authentication 사용자: {}", userRecord.getUid());
+                    } catch (Exception e) {
+                        // 존재하지 않으면 새로 생성 (UID 자등오르 랜덤 생성됨)
+                        UserRecord.CreateRequest createRequest = new UserRecord.CreateRequest()
+                                .setEmail(user.getEmail())
+                                .setDisplayName(user.getName());
+                        userRecord = FirebaseAuth.getInstance().createUser(createRequest);
+                        log.info("새 Firebase Authentication 사용자 생성됨: {}", userRecord.getUid());
+
+                        // Users 업데이트
+                        user.setFirebaseAuthUID(userRecord.getUid());
+                        userRepository.update(user);
+                    }
+                } catch (Exception e) {
+                    log.error("Firebase 사용자 생성 중 오류", e);
+                    throw new CustomException("Firebase 사용자 등록 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+
+            // 6. UID 포함한 사용자 정보로 Authentication 객체 다시 생성
+            CustomOAuth2UserDetails updatedUserDetails = new CustomOAuth2UserDetails(user);
+            Authentication updatedAuth = new UsernamePasswordAuthenticationToken(updatedUserDetails, null, updatedUserDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(updatedAuth);
+
+            // 7. fcmToken 디비에 업데이트
             fcmTokenService.save(nickname, fcmToken);
 
-            // 5. 새 디바이스에 푸시 예약 복구
+            // 8. 새 디바이스에 푸시 예약 복구
             saveFutureAlarm(nickname, fcmToken);
 
-            // 6. 인증 객체 (Authentication)을 바탕으로 JWT 토큰 생성
-            JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
+            // 9. 인증 객체 (Authentication)을 바탕으로 JWT 토큰 생성
+            JwtToken jwtToken = jwtTokenProvider.generateToken(updatedAuth);
             log.info("JwtToken created: accessToken = {}, refreshToken = {}", jwtToken.getAccessToken(), jwtToken.getRefreshToken());
 
-            // 7. Refresh 토큰 Redis 에 저장
+            // 10. Refresh 토큰 Redis 에 저장
             long expirationMinutes = jwtProperties.getRefreshTokenExpiration() / 1000 / 60; // ms → minutes
-
             refreshTokenService.saveToken(
                     (CustomOAuth2UserDetails) authentication.getPrincipal(),
                     jwtToken.getRefreshToken(),
@@ -133,14 +169,14 @@ public class UserService {
             );
             log.info("Saved refresh token in Redis: nickname={}, ttl={}min", nickname, expirationMinutes);
 
-            // 8. jwt 반환
+            // 11. jwt 반환
             return jwtToken;
         } catch (Exception e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다.");
         }
     }
 
-    public void withdraw(String accessToken, String fcmToken, String userId) throws ExecutionException, InterruptedException {
+    public String withdraw(String accessToken, String fcmToken, String userId, String uid) throws ExecutionException, InterruptedException {
         String nickname = jwtTokenProvider.getUserNickname(accessToken);
         Users user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
@@ -171,14 +207,25 @@ public class UserService {
             user.setProviderAccessToken(null); // 토큰 사용 후 파기
         }
 
-        // 4. 관련 데이터 삭제 (계획, 보상 등)
+        // 4. 관련 데이터 삭제 (계획, 보상, 피드백)
         planChildRepository.deleteAllByUserId(nickname);
         rewardChildRepository.deleteAllByUserId(nickname);
         feedbackRepository.deleteAllByUserId(nickname);
-        // 5. 사용자 문서 삭제
+
+        // 5. 유저 삭제
         userRepository.delete(user);
 
+        // 6. Firebase Authentication 사용자 삭제
+        try {
+            FirebaseAuth.getInstance().deleteUser(uid);
+            log.info("Firebase 사용자 삭제 완료: {}", uid);
+        } catch (FirebaseAuthException e) {
+            log.error("Firebase 사용자 삭제 실패: {}", e.getMessage());
+            throw new CustomException("Firebase 사용자 삭제 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
         log.info("회원 탈퇴 완료: {}", nickname);
+        return "Delete User Successfully";
     }
 
     public void unlinkSocial(String provider, String providerAccessToken){
@@ -295,7 +342,7 @@ public class UserService {
     }
 
     /**
-     * 소셜 로그인 성공 이후 추가 정보(역할) 업데이트
+     * 소셜 로그인 성공 이후 추가 정보(역할과 uid) 업데이트
      */
     public void updateUserRole(String nickname, String roleStr) {
         try {
@@ -303,12 +350,13 @@ public class UserService {
             Users user = userRepository.findByNickname(nickname)
                     .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
-            // 문자열을 UserRole Enum으로 변환
+            // 문자열을 UserRole Enum 으로 변환
             UserRole role = UserRole.fromString(roleStr);
-            user.setAuthority(role); // ✅ 역할 업데이트
-
+            // 역할 업데이트
+            user.setAuthority(role);
             userRepository.update(user);
             log.info("Updated successfully: {}, {}", nickname, role);
+
         } catch (ExecutionException e) {
             log.error("Firestore ExecutionException Error.. {}", e.getMessage());
             throw new RuntimeException("Firestore 데이터 처리 중 오류 발생", e);

--- a/src/main/java/com/example/iplan/auth/Users.java
+++ b/src/main/java/com/example/iplan/auth/Users.java
@@ -47,4 +47,7 @@ public class Users {
 
     @Schema(description = "소셜 플랫폼에서 받은 access token")
     private String providerAccessToken;
+
+    @Schema(description = "Firebase Auth가 생성한 UID (실시간 데이터 변경 감지를 위해)")
+    private String firebaseAuthUID;
 }

--- a/src/main/java/com/example/iplan/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/iplan/auth/jwt/JwtTokenProvider.java
@@ -207,8 +207,8 @@ public class JwtTokenProvider {
     public String generateNewAccessToken(Authentication authentication) {
         CustomOAuth2UserDetails userDetails = (CustomOAuth2UserDetails) authentication.getPrincipal();
 
-        String nickname = userDetails.getUser().getNickname();
-        String email = userDetails.getUser().getEmail();
+        String nickname = userDetails.getUsername();
+        String email = userDetails.getEmail();
         List<String> linked_id = userDetails.getUser().getLinked_id();
         UserRole role = userDetails.getUser().getAuthority();
 

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserDetails.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserDetails.java
@@ -44,6 +44,9 @@ public class CustomOAuth2UserDetails implements OAuth2User, UserDetails {
     // 사용자 이메일 가져오기
     public String getEmail() { return user.getEmail(); }
 
+    // 사용자 Firebase Authentication UID 가져오기
+    public String getFirebaseAuthUID() { return user.getFirebaseAuthUID(); }
+
     // 사용자 비밀번호 (OAuth2 로그인 시 null)
     @Override
     public String getPassword() {

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
@@ -104,6 +104,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .password("")   // 소셜 로그인은 비밀번호 없음
                         .authority(UserRole.UNKNOWN) // UserRole 타입으로 직접 전달, 아직 권한 미지정
                         .linked_id(new ArrayList<>()) // 빈 리스트로 초기화
+                        .firebaseAuthUID("")    // 추가 정보 입력 시에 받아서 저장
                         .provider(provider)
                         .providerAccessToken(providerAccessToken)
                         .build();

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
@@ -104,7 +104,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .password("")   // 소셜 로그인은 비밀번호 없음
                         .authority(UserRole.UNKNOWN) // UserRole 타입으로 직접 전달, 아직 권한 미지정
                         .linked_id(new ArrayList<>()) // 빈 리스트로 초기화
-                        .firebaseAuthUID("")    // 추가 정보 입력 시에 받아서 저장
+                        .firebaseAuthUID("")    // OAuth2SuccessHandler 에서 저장
                         .provider(provider)
                         .providerAccessToken(providerAccessToken)
                         .build();

--- a/src/main/java/com/example/iplan/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/OAuth2SuccessHandler.java
@@ -1,13 +1,18 @@
 package com.example.iplan.auth.oauth2;
 
+import com.example.iplan.auth.UserRepository;
+import com.example.iplan.auth.UserService;
 import com.example.iplan.auth.Users;
 import com.example.iplan.auth.jwt.JwtToken;
 import com.example.iplan.auth.jwt.JwtTokenProvider;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.UserRecord;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.User;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -26,6 +31,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final UserRepository userRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -38,6 +44,33 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         if (user == null) {
             log.error("OAuth2 login error: No user info");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "OAuth2 로그인 중 사용자 정보가 없습니다.");
+            return;
+        }
+
+        // Firebase Authentication 사용자 생성 또는 가져오기
+        try {
+            UserRecord userRecord;
+            try {
+                // 이메일로 이미 존재하는지 확인
+                userRecord = FirebaseAuth.getInstance().getUserByEmail(user.getEmail());
+                log.info("기존 Firebase Authentication 사용자: {}", userRecord.getUid());
+            } catch (Exception e) {
+                // 존재하지 않으면 새로 생성 (UID 자등오르 랜덤 생성됨)
+                UserRecord.CreateRequest createRequest = new UserRecord.CreateRequest()
+                        .setEmail(user.getEmail())
+                        .setDisplayName(user.getName());
+
+                userRecord = FirebaseAuth.getInstance().createUser(createRequest);
+                log.info("새 Firebase Authentication 사용자 생성됨: {}", userRecord.getUid());
+            }
+
+            // UID 사용자 정보 업데이트
+            user.setFirebaseAuthUID(userRecord.getUid());
+            userRepository.update(user);
+            log.info("UID 업데이트 성공: {}", userRecord.getUid());
+        } catch (Exception e) {
+            log.error("Firebase 사용자 생성 중 오류", e);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Firebase 사용자 등록 중 오류 발생");
             return;
         }
 

--- a/src/main/java/com/example/iplan/fcm/FcmRequestService.java
+++ b/src/main/java/com/example/iplan/fcm/FcmRequestService.java
@@ -40,7 +40,11 @@ public class FcmRequestService {
         // 메시지 빌드
         Message message = Message.builder()
                 .setToken(requestDTO.getFcmToken())
-                .setNotification(notification)
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(AndroidConfig.Priority.HIGH) // 우선 순위를 HIGH로 설정
+                        .build())
+                .putData("title", requestDTO.getNotification().getTitle())
+                .putData("body", requestDTO.getNotification().getBody())
                 .putData("pendingRequestId", pendingRequestId)
                 .putData("sender", sender)
                 .putData("type", type)


### PR DESCRIPTION
### 1. Firebase Authentication 사용자 로그인이 되어야만 onSnapshot()을 사용할 수 있음
- 백엔드에서 최초 로그인 시에 **UID 발급(Authentication에 **사용자 계정을 생성) 및 커스텀 토큰 발급**하여 프론트에서 Firebase Auth에 로그인**할 수 있도록 함
- Why?? 프론트에서 파이어베이스의 onsnapshot()을 사용하여 데이터의 실시간 데이터 변경을 감지하기 위해서는 Firebase Auth에 로그인 해야함. 이때 UID가 발급되는데, 추후에 회원탈퇴를 할 때 Firebase에서 계정을 없애기 위해서는 해당 UID가 필요하므로 유저에 저장해둠. 참고로 UID 자체로는 외부에서 쓸 수 있는 용도가 없기 때문에 따로 **UID는 암호화 진행 안해도 무관** 🔒 
- `아직 소셜로그인 시에 커스텀 토큰을 발급 받아 프론트에서 로그인을 하는 로직이 추가 안되어있음!!! (추가 예정)
`

### 2. FCM 메시지 형식 수정
- 푸시알람 보낼 때 백그라운드에서 헤드업으로 알림이 안오는 오류
- 백그라운드에서 notification을 수신했을 때는 메시지를 작업 표시줄에서 처리하고, 백그라운드에서 data를 수신했을 때는 onMessageReceived에서 처리함.
- 포그라운드(앱 실행 중)에서는 notification, data 중 아무것이나 수신해도 onMessageReceived에서 처리함
- 즉, 푸시 알림을 서버 측에서 notification 타입으로 보내주면 헤드업 알림이 제대로 발생하지 않음
- 안드로이드에서는 data 타입으로 수신하여 해당 값을 가공해 알림을 사용자에게 보여주어야 하기 때문에 **기존에 notification에 담겨진 title과 body를 모두 data 형식으로 수정**

### 3. 프론트에서 onSnapshot()으로 데이터 변경을 감지하여 해당 문서의 데이터 값을 가져오도록 요청
- 각각 Plan, Reward, Feedback에 대해 단일 문서 반환 등과 같은 메서드 생성

