### PR TITLE
CICD 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -56,6 +56,24 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # iplan-firebase.json 생성
+      - name: Create Firebase Key
+        run: |
+          mkdir ./src/main/resources || true
+          cd ./src/main/resources
+          rm -rf ./iplan-firebase.json || true
+          echo "${{ secrets.FIREBASE_KEY }}" | base64 --decode > ./iplan-firebase.json
+        shell: bash
+
+      # GOOGLE_APPLICATION_CREDENTIALS 파일 생성
+      - name: Create Firebase Key
+        run: |
+          mkdir ./src/main/resources || true
+          cd ./src/main/resources
+          rm -rf ./iplan-google.json || true
+          echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" | base64 --decode > ./iplan-google.json
+        shell: bash
+
       # 2. Spring Boot 애플리케이션 빌드
       - name: Build with Gradle
         run: ./gradlew clean bootJar --no-daemon --warning-mode all

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ out/
 .vscode/
 /src/main/resources/iplan-firebase.json
 /src/main/resources/iplan-3e9c2-feef2236cd5b.json
+/src/main/resources/iplan-google.json
 application.yml
 application-oauth2.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM openjdk:17
 # 작업 디렉토리 설정
 WORKDIR /app
 
+# JSON 키 파일들 복사
+COPY src/main/resources/iplan-firebase.json /app/
+COPY src/main/resources/iplan-google.json /app/
+
 # 인자 설정 - JAR_File
 ARG JAR_FILE=build/libs/*.jar
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,11 +14,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/app/iplan-3e9c2-feef2236cd5b.json
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/iplan-google.json
       - FIREBASE_CONFIG_PATH=/app/iplan-firebase.json
-    volumes:
-      - /home/ubuntu/iplan-3e9c2-feef2236cd5b.json:/app/iplan-3e9c2-feef2236cd5b.json
-      - /home/ubuntu/iplan-firebase.json:/app/iplan-firebase.json
     networks:
       - myboot
 

--- a/src/main/java/com/example/iplan/Controller/AccountParentController.java
+++ b/src/main/java/com/example/iplan/Controller/AccountParentController.java
@@ -28,6 +28,7 @@ public class AccountParentController {
     private final AccountParentService accountParentService;
     private final UserRepository userRepository;
 
+    // 부모가 아이에게 연동 요청 보냄
     @Operation(summary = "부모가 아이 계정 연동 요청을 보냄 POST", description = "해당 요청을 PendingAccountRequest 저장")
     @PostMapping("/link-child")
     public ResponseEntity<Map<String, Object>> parentAccountRequest(@RequestBody @NotNull AccountRequestDTO requestDTO, @AuthenticationPrincipal CustomOAuth2UserDetails user)
@@ -42,6 +43,7 @@ public class AccountParentController {
         return accountParentService.sendAccountRequest(childNickname, parentNicknameHash, parentNickname);
     }
 
+    // 부모가 이미 보낸 연동요청이 있는지 체크
     @GetMapping("/check-pending-status")
     public ResponseEntity<Map<String, Object>> checkPendingStatus(@AuthenticationPrincipal CustomOAuth2UserDetails user) {
         log.info("Check pending status API from parent received");

--- a/src/main/java/com/example/iplan/auth/AuthController.java
+++ b/src/main/java/com/example/iplan/auth/AuthController.java
@@ -47,16 +47,16 @@ public class AuthController {
         String accessToken = request.getAccessToken();
         String refreshToken = request.getRefreshToken();
 
-        // 1. accessToken 에서 nickname 추출
-        String nickname;
+        // 1. accessToken 에서 암호화 되어있는!! nickname 추출
+        String encryptedNickname;
         try {
-            nickname = jwtTokenProvider.getUserNickname(accessToken);
+            encryptedNickname = jwtTokenProvider.getEncryptedId(accessToken);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 AccessToken입니다.");
         }
 
         // 2. Redis에서 refreshToken 조회 및 검증
-        Optional<RefreshToken> optional = refreshTokenService.getToken(nickname);
+        Optional<RefreshToken> optional = refreshTokenService.getToken(encryptedNickname);
       
         if (optional.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("RefreshToken이 만료되었거나 존재하지 않습니다. 다시 로그인 해주세요.");
@@ -79,8 +79,8 @@ public class AuthController {
 //         테스트용: 1분으로 설정
 //        long oneWeekMillis = 60 * 1000;
 
-        // 5. accessToken 은 항상 새로 발급
-        // 6. refreshToken 은 조건에 따라 새로 발급하거나 유지
+
+        // 5. refreshToken 은 조건에 따라 새로 발급하거나 유지
         JwtToken newToken;
         if (remainingMillis <= oneWeekMillis) {
             log.info("RefreshToken 남은 기간이 7일 이내 → 갱신 수행");
@@ -90,6 +90,7 @@ public class AuthController {
             refreshTokenService.saveToken((CustomOAuth2UserDetails) authentication.getPrincipal(), newToken.getRefreshToken(), expirationMinutes);
         } else {
             log.info("RefreshToken 충분히 남아 있음 → accessToken만 재발급");
+            // 6. accessToken 은 항상 새로 발급
             String newAccessToken = jwtTokenProvider.generateNewAccessToken(authentication);
 
             newToken = JwtToken.builder()

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -68,7 +68,7 @@ public class UserService {
     // 회원가입
     public String signUp(String nickname, String password, String name, String email, String roleStr) {
         try {
-            // 1. 아이디 중복 확인
+            // 1. 아이디 중복 확인 (닉네임 해시값으로 중복 비교)
             if (nickname != null && userRepository.findByHashValueNickName(DigestUtils.sha256Hex(nickname)).isPresent()) {
                 throw new CustomException("Nickname already exists.", HttpStatus.NOT_FOUND);
             }

--- a/src/main/java/com/example/iplan/auth/Users.java
+++ b/src/main/java/com/example/iplan/auth/Users.java
@@ -30,6 +30,7 @@ public class Users {
     @Schema(description = "사용자 이메일", example = "abcd@gmail.com", requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
+    @Schema(description = "사용자 이메일 해시값")
     private String emailHash;
 
     @NotNull

--- a/src/main/java/com/example/iplan/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/iplan/auth/jwt/JwtTokenProvider.java
@@ -35,9 +35,6 @@ public class JwtTokenProvider {
 
     private final AES256Encryptor aes;
 
-//    public static final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24; // 24시간
-//    public static final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24 * 30; // 30일
-
     // JwtProperties 를 통해 생성자 내부에서 key 를 초기화
     public JwtTokenProvider(
             RefreshTokenService refreshTokenService,
@@ -91,8 +88,8 @@ public class JwtTokenProvider {
         // Access Token 생성
         Date accessTokenExpiresIn = new Date(now + accessTokenExpiration);
         String accessToken = Jwts.builder()
-                .setSubject(aes.decrypt(nickname))
-                .claim("encryptedId", nickname)
+                .setSubject(aes.decrypt(nickname))  // 복호화된 닉네임!!
+                .claim("encryptedId", nickname)     // 암호화된 닉네임!!
                 .claim("email", aes.decrypt(email))
                 .claim("role", role.name()) // Enum 값 저장 (CHILD, PARENT)
                 .claim("linked_id", decodedLinkedId)  // 리스트로 저장
@@ -214,6 +211,9 @@ public class JwtTokenProvider {
     public String getUserNickname(String token) {
         return parseClaims(token).getSubject();
     }
+
+    // 토큰의 암호화된 nickname(subject)을 가져옴
+    public String getEncryptedId(String token) { return parseClaims(token).get("encryptedId", String.class); }
 
     // 토큰의 만료시간 가져옴
     public Date getExpirationDate(String token) {

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserDetails.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserDetails.java
@@ -53,7 +53,7 @@ public class CustomOAuth2UserDetails implements OAuth2User, UserDetails {
         return user.getPassword();
     }
 
-     // Spring Security 에서 사용할 사용자 이름 (닉네임)
+     // Spring Security 에서 사용할 사용자 이름 (닉네임) -> 암호화 되어있음!!
      // Spring Security 의 인증 과정에서 사용자 식별을 위해 호출
      @Override
      public String getUsername() {

--- a/src/main/java/com/example/iplan/auth/redis/RefreshToken.java
+++ b/src/main/java/com/example/iplan/auth/redis/RefreshToken.java
@@ -26,7 +26,7 @@ public class RefreshToken {
     private Long expiration;
 
     public RefreshToken(CustomOAuth2UserDetails userDetails, String refreshToken, Long expiration){
-        this.id = userDetails.getUsername();    // 사용자 닉네임이 식별자
+        this.id = userDetails.getUsername();    // 암호화 되어있는 사용자 닉네임이 식별자
         this.refreshToken = refreshToken;
         this.expiration = expiration;
     }


### PR DESCRIPTION
### ❓ 인스턴스 재생성하는 과정에서 서버에 키 값들(파이어베이스, 구글) 두는게 안전하지 않다고 판단
### ✅ Github Action Secret에 키 값들 저장하여 gradle.yml에서 CI/CD 과정에 해당 값들을 생성하도록 수정!!
<img width="784" height="117" alt="image" src="https://github.com/user-attachments/assets/df4e59d5-6736-46d1-b4c7-9c11e9c16f49" />

### ✅ 서버에는 docker-compose 파일만 존재하도록
<img width="287" height="58" alt="image" src="https://github.com/user-attachments/assets/f2ae3f4f-c35a-47c9-a165-e2558179c891" />


1. `gradle.yml`
   - Github Secret에 JSON 내용 저장 (Base64 인코딩) 후에 CI 과정에서 해당 파일들을 생성하도록 추가
   - <img width="821" height="400" alt="image" src="https://github.com/user-attachments/assets/8fecb94a-8159-473f-a536-9d71857eec68" />

2. `Dockerfile`
   - Docker 이미지 안에 *.json 파일 포함하기
   - CI 과정에서 Github Secret에 저장한 json 파일들을 생성하고 있음. 이들을 이미지에 복사해서 포함되도록 Dockerfile에서 수정
   - <img width="413" height="85" alt="image" src="https://github.com/user-attachments/assets/74661799-11a2-4cbc-9967-bc351f7217ed" />

3. `compose.yml`
   - EC2 서버에 서비스 계정 키(json) 파일들을 저장해놓지 않고, Github Action Secret에 추가하여 가져오는 방식으로 수정함에 따라 docker-compose 파일에서 **볼륨 설정할 필요가 없어짐(제거)**
   - environment 만 설정(이미 이미지 생성 시에 /app 경로로 파일들을 복사해뒀으므로)
   - <img width="512" height="234" alt="image" src="https://github.com/user-attachments/assets/4828bffd-b9f4-4833-915a-3a8b3e0cc6d0" />

