### PR TITLE
[feat] 부모 스크린타임:

### DIFF
--- a/src/main/java/com/example/iplan/Controller/ParentScreenTimeController.java
+++ b/src/main/java/com/example/iplan/Controller/ParentScreenTimeController.java
@@ -2,35 +2,53 @@ package com.example.iplan.Controller;
 
 import com.example.iplan.Service.ParentScreenTimeService;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
+import com.example.iplan.util.AES256Encryptor;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/parent/screen-time")
 public class ParentScreenTimeController {
 
     private final ParentScreenTimeService parentScreenTimeService;
+    private final AES256Encryptor aes;
 
     @GetMapping("/showTimeSet/{targetDate}")
-    public ResponseEntity<Map<String, Object>> GetScreenTime(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws ExecutionException, InterruptedException{
-        System.out.println("User ID: " + user.getUsername() + ", Target Date: " + targetDate);
+    public ResponseEntity<Map<String, Object>> GetScreenTime(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws Exception {
+        log.info("User ID: " + aes.decrypt(user.getUsername()) + ", Target Date: " + targetDate);
 
         return parentScreenTimeService.getScreenTime(user.getUsername(), targetDate);
     }
 
     @GetMapping("/showScreenTimeGraph/{targetDate}")
     public ResponseEntity<Map<String, Object>> GetScreenTimeGraph(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws Exception {
-        System.out.println("User ID: " + user.getUsername() + ", Target Date: " + targetDate );
+        log.info("User ID: " + aes.decrypt(user.getUsername()) + ", Target Date: " + targetDate );
 
         return parentScreenTimeService.getScreenTimeGraph(user.getUsername(), targetDate);
+    }
+
+    @GetMapping("/time-set/detection/add")
+    public ResponseEntity<Map<String, Object>> GetOneTimeData(@AuthenticationPrincipal CustomOAuth2UserDetails user, @RequestParam("docId") String docId, @RequestParam("childId") String childId) throws Exception {
+        String parentEncryptedNickname = user.getUsername();
+        log.info("User Id:" + aes.decrypt(parentEncryptedNickname) + ", Target Time Id: " + docId);
+        Map<String, Object> response = parentScreenTimeService.getOneTimeData(parentEncryptedNickname, docId, childId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/graph/detection/add")
+    public ResponseEntity<Map<String, Object>> GetOneGraphData(@AuthenticationPrincipal CustomOAuth2UserDetails user, @RequestParam("graphId") String graphId, @RequestParam("childId") String childId) throws Exception {
+        String parentEncryptedNickname = user.getUsername();
+        log.info("User ID: " + aes.decrypt(parentEncryptedNickname) + ", Target Graph Id: " + graphId);
+        Map<String, Object> response = parentScreenTimeService.getOneGraphData(parentEncryptedNickname, graphId, childId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
+++ b/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
@@ -52,7 +52,7 @@ public class ScreenTimeController {
     }
 
     @GetMapping("/showTimeSet/{targetDate}")
-    public ResponseEntity<Map<String, Object>> GetScreenTime(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws ExecutionException, InterruptedException{
+    public ResponseEntity<Map<String, Object>> GetScreenTime(@AuthenticationPrincipal CustomOAuth2UserDetails user, @PathVariable String targetDate) throws Exception {
         String childNickname = user.getUsername();
         return screenTimeService.getScreenTime(childNickname, targetDate);
     }

--- a/src/main/java/com/example/iplan/DTO/ScreenTimeResultDTO.java
+++ b/src/main/java/com/example/iplan/DTO/ScreenTimeResultDTO.java
@@ -33,7 +33,7 @@ public class ScreenTimeResultDTO {
     public static ScreenTimeResultDTO fromEntity(ScreenTimeOCRResult result, AES256Encryptor aes) throws Exception {
         return ScreenTimeResultDTO.builder()
                 .id(result.getId())
-                .user_id(result.getUser_id())
+                .user_id(aes.decrypt(result.getUser_id()))
                 .date(result.getDate())
                 .result(aes.decryptJsonObject(result.getResult(), new TypeReference<>() {}))
                 .isSuccess(result.isSuccess())

--- a/src/main/java/com/example/iplan/Repository/DefaultFirebaseRepository/DefaultFirebaseDBRepository.java
+++ b/src/main/java/com/example/iplan/Repository/DefaultFirebaseRepository/DefaultFirebaseDBRepository.java
@@ -1,10 +1,12 @@
 package com.example.iplan.Repository.DefaultFirebaseRepository;
 
+import com.example.iplan.ExceptionHandler.CustomException;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.*;
 import com.google.cloud.firestore.annotation.DocumentId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
@@ -211,9 +213,9 @@ public class DefaultFirebaseDBRepository<T> implements FirebaseDBRepository<T, S
 
         if(documentSnapshot.exists()){
             return documentSnapshot.toObject(entityClass);
+        }else{
+            throw new CustomException("해당 ID의 그래프 데이터 문서가 없습니다.", HttpStatus.NOT_FOUND);
         }
-
-        return null;
     }
 
     /**

--- a/src/main/java/com/example/iplan/Service/ParentScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ParentScreenTimeService.java
@@ -15,10 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 @Service
@@ -52,7 +49,7 @@ public class ParentScreenTimeService {
             response.put("success", false);
             response.put("message", "연동된 아이들 중 스크린타임 분석 그래프 대한 데이터가 존재하지 않습니다.");
 
-            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
         response.put("entity", child_OCRresult_list);
@@ -61,7 +58,7 @@ public class ParentScreenTimeService {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Object>> getScreenTime(String user_id, String targetDate) throws ExecutionException, InterruptedException {
+    public ResponseEntity<Map<String, Object>> getScreenTime(String user_id, String targetDate) throws Exception {
         List<String> child_id = getTargetChildID(user_id);
 
         if(!isCollectLinkedID(user_id, child_id))
@@ -72,21 +69,64 @@ public class ParentScreenTimeService {
 
         for(String child : child_id){
             ScreenTime result = setScreenTimeRepository.findByDate(child, targetDate);
+            result.setUser_id(aes.decrypt(result.getUser_id()));
 
-            if(result != null) child_screenTime_list.add(result);
+            child_screenTime_list.add(result);
         }
 
         if(child_screenTime_list.isEmpty()){
             response.put("success", false);
             response.put("message", "연동된 아이들 중 스크린타임 타임셋에 대한 데이터가 존재하지 않습니다.");
 
-            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
         response.put("entity", child_screenTime_list);
         response.put("success", true);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    public Map<String, Object> getOneGraphData(String parentEncryptedNickname, String graphId, String childId) throws ExecutionException, InterruptedException {
+        Map<String, Object> response = new HashMap<>();
+
+        ScreenTimeOCRResult graphData = getScreenTimeOCRRepository.findEntityByDocumentId(graphId);
+
+        try{
+            if(graphData != null){
+                if(!Objects.equals(graphData.getUser_id(), childId)){
+                    throw new CustomException("해당 그래프 데이터에 대한 접근 권한이 없습니다.", HttpStatus.NOT_ACCEPTABLE);
+                }
+                ScreenTimeResultDTO resultDTO = ScreenTimeResultDTO.fromEntity(graphData, aes);
+                response.put("success", true);
+                response.put("entity", resultDTO);
+            }
+        }catch (Exception e){
+            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return response;
+    }
+
+    public Map<String, Object> getOneTimeData(String parentEncryptedNickname, String docId, String childId) throws ExecutionException, InterruptedException {
+        Map<String, Object> response = new HashMap<>();
+
+        ScreenTime screenTime = setScreenTimeRepository.findEntityByDocumentId(docId);
+
+        try{
+            if(screenTime != null){
+                if(!Objects.equals(screenTime.getUser_id(), childId)){
+                    throw new CustomException("해당 스크린타임 시간 데이터에 대한 접근 권한이 없습니다.", HttpStatus.NOT_ACCEPTABLE);
+                }
+                screenTime.setUser_id(aes.decrypt(screenTime.getUser_id()));
+                response.put("success", true);
+                response.put("entity", screenTime);
+            }
+        }catch (Exception e){
+            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return response;
     }
 
     private boolean isCollectLinkedID(String user_id, List<String> child_id){

--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -74,12 +74,12 @@ public class ScreenTimeService {
 
             System.out.println("result null이어서 false response 발송");
 
-            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
         ScreenTimeResultDTO resultDTO = ScreenTimeResultDTO.builder()
                         .id(result.getId())
-                        .user_id(result.getUser_id())
+                        .user_id(aes.decrypt(result.getUser_id()))
                         .date(result.getDate())
                         .result(aes.decryptJsonObject(result.getResult(), new TypeReference<Map<String, Object>>() {}))
                         .isSuccess(result.isSuccess())
@@ -93,7 +93,7 @@ public class ScreenTimeService {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    public ResponseEntity<Map<String, Object>> getScreenTime(String user_id, String targetDate) throws ExecutionException, InterruptedException {
+    public ResponseEntity<Map<String, Object>> getScreenTime(String user_id, String targetDate) throws Exception {
         Map<String, Object> response = new HashMap<>();
 
         System.out.println("사용자 아이디: "+user_id+", 날짜: "+targetDate);
@@ -104,12 +104,13 @@ public class ScreenTimeService {
             response.put("success", false);
             response.put("message", "해당 날짜의 설정된 스크린 타임이 없습니다.");
 
-            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
         String deadlineTime = result.getDeadLineTime();
         String goalTime = result.getGoalTime();
 
+        response.put("user_id", aes.decrypt(result.getUser_id()));
         response.put("date", targetDate);
         response.put("deadLineTime", deadlineTime);
         response.put("goalTime", goalTime);


### PR DESCRIPTION
## ✅ 주요 변경 사항

### 1. [feat] 부모 스크린타임 실시간 감지를 위한 API 추가
- 부모 계정이 자녀의 스크린타임 활동을 실시간으로 확인할 수 있도록 하기 위해,
  다음 데이터에 대한 감지용 컨트롤러 및 서비스 로직 추가:
  - 자녀의 **목표 시간 설정 추가 감지** → `/parent/screen-time/time-set/detection/add`
  - 자녀의 **스크린타임 사진 업로드 및 분석 결과 추가 감지** → `/parent/screen-time/graph/detection/add`
- 감지된 `docId`와 `childId`를 기반으로 최신 데이터를 조회하여 반환
- 클라이언트의 Firestore `onSnapshot` 이벤트와 연동되어 동작

---

### 2. [fix] 암복호화 처리 오류 수정
- 스크린타임 그래프 및 시간 데이터를 가져오는 곳에서 발생하던 암복호화 관련 오류 해결
- 에러 발생 조건에 대한 방어 로직 및 예외 메시지 명확화 처리

---

## 🧪 테스트 항목

- [x] 자녀가 목표 시간을 설정하면 부모 API `/time-set/detection/add`에서 올바른 데이터가 반환되는지 확인
- [x] 자녀가 사진 업로드 후 분석을 완료하면 부모 API `/graph/detection/add`를 통해 분석 결과가 정상 반환되는지 확인
- [x] 암호화/복호화 로직에서 예외가 발생하지 않고 정상 연동이 유지되는지 확인
