### PR TITLE
[Bugfix] 스크린타임 사진 첫 업로드시, ‘path’ must be a non-empty String 오류

### DIFF
--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -350,6 +350,10 @@ public class ScreenTimeService {
                 }
             }
 
+            if(categories.isEmpty()){
+                log.info("사용자 기기에 추가되지 않은 어플이 있습니다.");
+                throw new CustomException("사진과 사용자 기기의 정보가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+            }
             result.put(KEY_CATEGORIES, categories);
             return result;
         }catch(Exception e){

--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -150,7 +150,8 @@ public class ScreenTimeService {
 
                 String filename = image.getOriginalFilename();
                 if (filename == null || filename.trim().isEmpty()) {
-                    throw new CustomException("파일 이름이 비어 있거나 잘못되었습니다.", HttpStatus.BAD_REQUEST);
+                    log.info("파일 이름이 null 또는 비어 있음. UUID로 대체.");
+                    filename = UUID.randomUUID() + ".jpg";
                 }
 
                 Path tempDir = Files.createTempDirectory("upload");
@@ -225,7 +226,7 @@ public class ScreenTimeService {
             } catch (Exception e) {
                 System.out.println("Error: " + e.getMessage());
                 e.printStackTrace();
-                throw new CustomException("파일 업로드 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+                throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }else{
             throw new CustomException("설치된 앱 목록이 존재하지 않습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -189,7 +189,7 @@ public class UserService {
             // 11. jwt 반환
             return jwtToken;
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다.");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인 실패: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -419,7 +419,7 @@ public class UserService {
         String encoded = passwordEncoder.encode(rawPassword);
 
         List<QueryDocumentSnapshot> docs = firestore.collection("User")
-                .whereEqualTo("encryptEmail", encryptEmail)
+                .whereEqualTo("email", encryptEmail)
                 .get()
                 .get()
                 .getDocuments();


### PR DESCRIPTION
- [bugfix] 스크린타임 사진 첫 업로드시, ‘path’ must be a non-empty String 오류가 뜸, 무시 이후부터는 업로드 문제 없음
→ 원인불명, 알아내기가 너무 힘듬, 프론트에서 formData 보낼때의 로그는 전혀 문제가 없고, 백에서는 여러가지 디버깅을 시도했지만, 여전히 오리무중임
→ 추측:  MultipartFile 내부 name 필드가 비어있을 수 있고, 그것이 곧바로 resolve에 사용되어서 오류 발생
→ 원인은 불명하나, null 체크 후 UUID로 파일명 대체하는 방어 코드를 짜서 보완하기로 결정

- [bugfix] firestore 잘못된 필드 매핑 수정
- [bugfix]  애초에 스크린타임 사진 집어넣을때, 카테고리 영역이 모두 비게되면(앱 설치 목록과 사진 정보가 일치하지 않음) 유효하지 않는 사진이라고 경고뜨게 하고 디비에 저장 못하게 막음