### PR TITLE
[Bugfix] CustomException 구조 변경, 보호자 동의 메일 전송 구현

### DIFF
--- a/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
+++ b/src/main/java/com/example/iplan/Controller/ScreenTimeController.java
@@ -5,7 +5,6 @@ import com.example.iplan.Service.ScreenTimeService;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -17,10 +16,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 @Controller
 @Slf4j
@@ -42,7 +39,7 @@ public class ScreenTimeController {
                 ObjectMapper objectMapper = new ObjectMapper();
                 installedApps = objectMapper.readValue(installedAppsJson, new TypeReference<>() {});
             } catch (JsonProcessingException e) {
-                throw new CustomException("앱 목록 파싱 실패", HttpStatus.BAD_REQUEST);
+                throw new CustomException("앱 목록 파싱 실패", e.getMessage(), HttpStatus.BAD_REQUEST);
             }
         }else{
             System.out.println("앱 목록 비었거나 null임: " + installedAppsJson);

--- a/src/main/java/com/example/iplan/ExceptionHandler/CustomException.java
+++ b/src/main/java/com/example/iplan/ExceptionHandler/CustomException.java
@@ -2,15 +2,18 @@ package com.example.iplan.ExceptionHandler;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
 
 @Getter
 public class CustomException extends RuntimeException {
 
     private final HttpStatus status;
+    private final String detail;
 
-    public CustomException(String message, HttpStatus status) {
+    public CustomException(String message, @Nullable String detail, HttpStatus status) {
         super(message);
         this.status = status;
+        this.detail = detail;
     }
 }
 

--- a/src/main/java/com/example/iplan/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/iplan/ExceptionHandler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ public class GlobalExceptionHandler {
         Map<String, Object> response = new HashMap<>();
         response.put("success", false);
         response.put("message", ex.getMessage());
+        if(ex.getDetail() != null) response.put("detail", ex.getDetail());
 
         return new ResponseEntity<>(response, ex.getStatus());
     }

--- a/src/main/java/com/example/iplan/Repository/DefaultFirebaseRepository/DefaultFirebaseDBRepository.java
+++ b/src/main/java/com/example/iplan/Repository/DefaultFirebaseRepository/DefaultFirebaseDBRepository.java
@@ -219,7 +219,7 @@ public class DefaultFirebaseDBRepository<T> implements FirebaseDBRepository<T, S
         if(documentSnapshot.exists()){
             return documentSnapshot.toObject(entityClass);
         }else{
-            throw new CustomException("해당 ID의 데이터 문서가 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("일시적 오류가 발생하였습니다.", "데이터(" + collectionName +")에서 ID(" + document_id +") 문서를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/example/iplan/Repository/FeedbackRepository.java
+++ b/src/main/java/com/example/iplan/Repository/FeedbackRepository.java
@@ -1,17 +1,12 @@
 package com.example.iplan.Repository;
 
-import com.example.iplan.DTO.FeedbackDTO;
 import com.example.iplan.Domain.Feedback;
-import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.DefaultFirebaseRepository.DefaultFirebaseDBRepository;
-import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.*;
-import com.google.firebase.cloud.FirestoreClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -48,7 +43,7 @@ public class FeedbackRepository extends DefaultFirebaseDBRepository<Feedback> {
     public Feedback findFeedbackByID(String feedbackId) throws ExecutionException, InterruptedException {
         Feedback feedback = findEntityByDocumentId(feedbackId);
         if (feedback == null) {
-            throw new CustomException("해당 ID의 Feedback 문서가 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("일시적 오류가 발생하였습니다.","해당 ID:" + feedbackId + "의 Feedback 문서가 없습니다.", HttpStatus.NOT_FOUND);
         }
         return feedback;
     }

--- a/src/main/java/com/example/iplan/Repository/PlanChildRepository.java
+++ b/src/main/java/com/example/iplan/Repository/PlanChildRepository.java
@@ -8,9 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -49,7 +46,7 @@ public class PlanChildRepository extends DefaultFirebaseDBRepository<PlanChild> 
     public PlanChild findPlanByID(String planId) throws ExecutionException, InterruptedException {
         PlanChild planChild = findEntityByDocumentId(planId);
         if (planChild == null) {
-            throw new CustomException("해당 ID의 PlanChild 문서가 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("계획을 찾지 못했습니다.", "해당 ID: "+ planId +"를 PlanChild 문서에서 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
         return planChild;
     }

--- a/src/main/java/com/example/iplan/Repository/RewardChildRepository.java
+++ b/src/main/java/com/example/iplan/Repository/RewardChildRepository.java
@@ -1,6 +1,5 @@
 package com.example.iplan.Repository;
 
-import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.DTO.RewardChildDTO;
 import com.example.iplan.ExceptionHandler.CustomException;
@@ -10,7 +9,6 @@ import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
-import com.google.firebase.cloud.FirestoreClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
@@ -50,10 +48,10 @@ public class RewardChildRepository extends DefaultFirebaseDBRepository<RewardChi
     /**
      * Reward ID로 해당하는 문서 반환
      */
-    public RewardChild findRewardByID(String planId) throws ExecutionException, InterruptedException {
-        RewardChild rewardChild = findEntityByDocumentId(planId);
+    public RewardChild findRewardByID(String rewardId) throws ExecutionException, InterruptedException {
+        RewardChild rewardChild = findEntityByDocumentId(rewardId);
         if (rewardChild == null) {
-            throw new CustomException("해당 ID의 PlanChild 문서가 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("보상을 찾지 못했습니다.", "해당 ID: "+ rewardId +"를 RewardChild 문서에서 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
         return rewardChild;
     }

--- a/src/main/java/com/example/iplan/Service/AccountChildService.java
+++ b/src/main/java/com/example/iplan/Service/AccountChildService.java
@@ -46,12 +46,12 @@ public class AccountChildService {
         // 1. DTO에서 받아온 요청 ID로 PendingAccountRequest 조회 (부모가 요청 보낼 때 PendingAccountRequest 저장)
         PendingAccountRequest request = accountRepository.findEntityByDocumentId(dto.getId());
         if (request == null) {
-            throw new CustomException("해당 요청이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("일시적 오류가 발생하였습니다.","해당 요청:"+dto.getId()+"이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
         }
 
         // 2. (암호화된) 아이 닉네임 비교
         if (!request.getChildEncryptedNickname().equals(childEncryptedNickname)) {
-            throw new CustomException("본인의 요청만 처리할 수 있습니다.", HttpStatus.FORBIDDEN);
+            throw new CustomException("본인의 요청만 처리할 수 있습니다.", null, HttpStatus.FORBIDDEN);
         }
         log.info("아이의 암호화된 닉네임: {}", childEncryptedNickname);
 
@@ -63,7 +63,7 @@ public class AccountChildService {
         Users childUser = userRepository.findByEncryptedNickname(childEncryptedNickname).orElseThrow(() -> new IllegalArgumentException("해당 아이 유저가 존재하지 않습니다."));
         Users parentUser = userRepository.findByEncryptedNickname(parentEncryptedNickname).orElseThrow(() -> new IllegalArgumentException("해당 부모 유저가 존재하지 않습니다."));
         if (childUser == null || parentUser == null) {
-            throw new CustomException("유저 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("유저 정보를 찾을 수 없습니다.", null, HttpStatus.NOT_FOUND);
         }
 
         // 4. 아이의 linked_id가 이미 존재하는데 approved(승인)한 경우 -> 수락 불가(denied)
@@ -73,7 +73,7 @@ public class AccountChildService {
             request.setApproved(false);
             request.setStatus("denied");
             accountRepository.update(request);
-            throw new CustomException("이미 다른 계정과 연동되어 있어 수락할 수 없습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("이미 다른 계정과 연동되어 있어 수락할 수 없습니다.", null, HttpStatus.BAD_REQUEST);
         }
 
         // 5. 승인하는 경우
@@ -117,7 +117,7 @@ public class AccountChildService {
 
         // 자녀 유저 조회
         Users childUser = userRepository.findByEncryptedNickname(childEncryptedNickname)
-                .orElseThrow(() -> new CustomException("해당 닉네임의 자녀를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new CustomException("해당 닉네임의 자녀를 찾을 수 없습니다.", null, HttpStatus.NOT_FOUND));
 
         // 해당 요청 가져오기
         PendingAccountRequest accountRequest = accountRepository.findByRequestId(pendingRequestId);
@@ -165,7 +165,7 @@ public class AccountChildService {
                 log.warn("연동 요청을 보낼 아이({})의 FcmToken 이 존재하지 않습니다.", childEncryptedNickname);
             }
         } catch (Exception e) {
-            throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         // 응답 반환

--- a/src/main/java/com/example/iplan/Service/AccountParentService.java
+++ b/src/main/java/com/example/iplan/Service/AccountParentService.java
@@ -6,8 +6,6 @@ import com.example.iplan.Repository.AccountRepository;
 import com.example.iplan.auth.UserRepository;
 import com.example.iplan.auth.UserRole;
 import com.example.iplan.auth.Users;
-import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
-import com.example.iplan.auth.jwt.JwtToken;
 import com.example.iplan.auth.jwt.JwtTokenProvider;
 import com.example.iplan.fcm.FcmRequestDTO;
 import com.example.iplan.fcm.FcmRequestService;
@@ -19,8 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -52,12 +48,12 @@ public class AccountParentService {
 
         // 1. 자녀 유저 조회
         Users childUser = userRepository.findByHashValueNickName(childNicknameHash)
-                .orElseThrow(() -> new CustomException("해당 닉네임의 자녀를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new CustomException("해당 닉네임의 자녀를 찾을 수 없습니다.", null, HttpStatus.NOT_FOUND));
         String childEncryptedNickname = childUser.getNickname();    // 아이의 암호화된 닉네임
 
         // 2. 자녀인지 확인
         if (childUser.getAuthority() != UserRole.CHILD) {
-            throw new CustomException("입력한 닉네임은 자녀 계정이 아닙니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("입력한 닉네임은 자녀 계정이 아닙니다.", null, HttpStatus.BAD_REQUEST);
         }
 
         // 3. 이미 다른 부모와 연동된 자녀인지 확인
@@ -118,7 +114,7 @@ public class AccountParentService {
                 log.warn("연동 요청을 보낼 아이({})의 FcmToken 이 존재하지 않습니다.", childEncryptedNickname);
             }
         } catch (Exception e) {
-            throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         // 9. 응답 반환
@@ -143,7 +139,7 @@ public class AccountParentService {
                 log.info("암호화된 자녀 닉네임: {}", childEncryptedNickname);
 
                 // 유저가 존재하는지 확인
-                userRepository.findByEncryptedNickname(childEncryptedNickname).orElseThrow(() -> new CustomException("아이 사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+                userRepository.findByEncryptedNickname(childEncryptedNickname).orElseThrow(() -> new CustomException("아이 사용자를 찾을 수 없습니다", null, HttpStatus.NOT_FOUND));
 
                 // 복호화된 닉네임 얻기
                 String childDecryptedNickname = aes.decrypt(childEncryptedNickname);

--- a/src/main/java/com/example/iplan/Service/AlarmService.java
+++ b/src/main/java/com/example/iplan/Service/AlarmService.java
@@ -1,11 +1,8 @@
 package com.example.iplan.Service;
 
 import com.example.iplan.Domain.Alarm;
-import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.AlarmRepository;
-import com.example.iplan.Repository.PlanChildRepository;
-import com.example.iplan.scheduler.PushSchedulerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -36,7 +33,7 @@ public class AlarmService {
             alarmRepository.saveWithAutoIncrement(alarm);
             log.info("알람 저장 성공: {}", alarm.getId());
         } catch (Exception e) {
-            throw new CustomException("알림 저장 성공에 실패했습니다. Error: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("알림 저장에 실패했습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -53,7 +50,7 @@ public class AlarmService {
                 log.info("삭제할 알림이 존재하지 않음: planId = {} / fcmToken = {}", planId, fcmToken);
             }
         } catch (Exception e) {
-            throw new CustomException("알림을 컬렉션에서 삭제에 실패했습니다. Error: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("알림 삭제에 실패했습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -74,7 +71,7 @@ public class AlarmService {
                 log.info("삭제할 알림이 존재하지 않음: planId = {}", planId);
             }
         } catch (Exception e) {
-            throw new CustomException("알림을 컬렉션에서 삭제에 실패했습니다. Error: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("알림 삭제에 실패했습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/example/iplan/Service/FeedbackService.java
+++ b/src/main/java/com/example/iplan/Service/FeedbackService.java
@@ -46,7 +46,7 @@ public class FeedbackService {
             // 1. rewardID로 RewardChild 엔티티에서 해당 보상 검색
             RewardChild reward = rewardChildRepository.findEntityByDocumentId(feedbackDTO.getReward_id());
             if (reward == null) {
-                throw new CustomException("해당 ID의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+                throw new CustomException("피드백 설정에 실패하였습니다.", "해당 Id: "+feedbackDTO.getReward_id()+"를 RewardChild에서 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
             }
 
             String encryptedComment = aes.encrypt(feedbackDTO.getComment());
@@ -77,7 +77,7 @@ public class FeedbackService {
 
             return new ResponseEntity<>(response, HttpStatus.OK);
         } catch (Exception e) {
-            throw new CustomException("저장에 실패했습니다. Error: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("저장에 실패했습니다", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -174,10 +174,10 @@ public class FeedbackService {
             Feedback existingFeedback = feedbackRepository.findByField("reward_id", feedbackDTO.getReward_id());
 
             if (existingFeedback == null) {
-                throw new CustomException("해당 ID의 지급된 피드백을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+                throw new CustomException("피드백 수정 실패","해당 ID:" + feedbackDTO.getReward_id() +"의 지급된 피드백을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
             }
             if (!Objects.equals(existingFeedback.getUser_id(), parentNickname)) {
-                throw new CustomException("해당 피드백에 대한 수정 권한이 없습니다.", HttpStatus.UNAUTHORIZED);
+                throw new CustomException("해당 피드백에 대한 수정 권한이 없습니다.", null, HttpStatus.UNAUTHORIZED);
             }
 
             // 빌더 패턴을 사용하여 Feedback 객체를 새롭게 업데이트
@@ -198,7 +198,7 @@ public class FeedbackService {
             // 보상 객체도 함께 수정
             RewardChild reward = rewardChildRepository.findEntityByDocumentId(existingFeedback.getReward_id());
             if (reward == null) {
-                throw new CustomException("해당 ID의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+                throw new CustomException("보상 수정 실패", "해당 ID:" + existingFeedback.getReward_id() +"의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
             }
             reward.setRewarded(true);
             reward.setSuccess(feedbackDTO.isSuccess());
@@ -210,7 +210,7 @@ public class FeedbackService {
             log.info("피드백 수정 완료 id: {}", updateFeedback.getId());
             return new ResponseEntity<>(response, HttpStatus.OK);
         } catch (Exception e) {
-            throw new CustomException("수정에 실패했습니다. Error: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("피드백 수정 실패", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -225,17 +225,17 @@ public class FeedbackService {
             if (feedback != null) {
                 // 피드백의 user_id와 인증객체 유저와 일치한지 확인
                 if (!Objects.equals(feedback.getChild_id(), childNickname)) {
-                    throw new CustomException("해당 피드백에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                    throw new CustomException("해당 피드백에 대한 접근 권한이 없습니다.", null, HttpStatus.FORBIDDEN);  // 404 에러 반환
                 }
                 feedback.setUser_id(aes.decrypt(feedback.getUser_id()));
                 feedback.setChild_id(aes.decrypt(feedback.getChild_id()));
                 feedback.setComment(aes.decrypt(feedback.getComment()));
                 return Map.of("success", true, "message", feedbackId + " 피드백 반환 성공", "feedback", feedback);
             } else {
-                throw new CustomException(feedbackId + " ID의 피드백이 존재하지 않음", HttpStatus.NOT_FOUND);
+                throw new CustomException("일시적 오류가 발생하였습니다.",feedbackId + " ID의 피드백이 존재하지 않음", HttpStatus.NOT_FOUND);
             }
         } catch (Exception e) {
-            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/example/iplan/Service/ParentScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ParentScreenTimeService.java
@@ -5,7 +5,6 @@ import com.example.iplan.Domain.ScreenTime;
 import com.example.iplan.Domain.ScreenTimeOCRResult;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.GetScreenTimeOCRRepository;
-import com.example.iplan.Repository.InstalledAppsRepository;
 import com.example.iplan.Repository.SetScreenTimeRepository;
 import com.example.iplan.auth.UserRepository;
 import com.example.iplan.auth.Users;
@@ -30,7 +29,7 @@ public class ParentScreenTimeService {
         List<String> child_id = getTargetChildID(user_id);
 
         if(!isCollectLinkedID(user_id, child_id))
-            throw new CustomException("child_id 중 올치 않은 계정이 있습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("child_id 중 올치 않은 계정이 있습니다.", null, HttpStatus.BAD_REQUEST);
 
         Map<String, Object> response = new HashMap<>();
 
@@ -62,7 +61,7 @@ public class ParentScreenTimeService {
         List<String> child_id = getTargetChildID(user_id);
 
         if(!isCollectLinkedID(user_id, child_id))
-            throw new CustomException("child_id: "+ child_id + "는 연동된 계정이 아닙니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("child_id: "+ child_id + "는 연동된 계정이 아닙니다.", null, HttpStatus.BAD_REQUEST);
 
         Map<String, Object> response = new HashMap<>();
         List<ScreenTime> child_screenTime_list = new ArrayList<>();
@@ -96,14 +95,14 @@ public class ParentScreenTimeService {
         try{
             if(graphData != null){
                 if(!Objects.equals(graphData.getUser_id(), childId)){
-                    throw new CustomException("해당 그래프 데이터에 대한 접근 권한이 없습니다.", HttpStatus.NOT_ACCEPTABLE);
+                    throw new CustomException("해당 그래프 데이터에 대한 접근 권한이 없습니다.", null, HttpStatus.NOT_ACCEPTABLE);
                 }
                 ScreenTimeResultDTO resultDTO = ScreenTimeResultDTO.fromEntity(graphData, aes);
                 response.put("success", true);
                 response.put("entity", resultDTO);
             }
         }catch (Exception e){
-            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         return response;
@@ -117,14 +116,14 @@ public class ParentScreenTimeService {
         try{
             if(screenTime != null){
                 if(!Objects.equals(screenTime.getUser_id(), childId)){
-                    throw new CustomException("해당 스크린타임 시간 데이터에 대한 접근 권한이 없습니다.", HttpStatus.NOT_ACCEPTABLE);
+                    throw new CustomException("해당 스크린타임 시간 데이터에 대한 접근 권한이 없습니다.", null, HttpStatus.NOT_ACCEPTABLE);
                 }
                 screenTime.setUser_id(aes.decrypt(screenTime.getUser_id()));
                 response.put("success", true);
                 response.put("entity", screenTime);
             }
         }catch (Exception e){
-            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         return response;
@@ -145,7 +144,7 @@ public class ParentScreenTimeService {
         List<String> child_id_list = parent != null ? parent.getLinked_id() : null;
 
         if(child_id_list == null){
-            throw new CustomException("해당 부모와 연동된 아이가 존재하지않습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("해당 부모와 연동된 아이가 존재하지않습니다.", null, HttpStatus.NOT_FOUND);
         }
 
         System.out.println("Target Child ID List: " + child_id_list.stream().toString());

--- a/src/main/java/com/example/iplan/Service/PlanCategoryService.java
+++ b/src/main/java/com/example/iplan/Service/PlanCategoryService.java
@@ -36,7 +36,7 @@ public class PlanCategoryService {
             planCategoryRepository.saveWithAutoIncrement(planCategory);
         }
         catch (Exception e){
-            throw new CustomException("계획 카테고리 추가에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("계획 카테고리 추가에 실패했습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         response.put("success", true);
@@ -93,14 +93,14 @@ public class PlanCategoryService {
                 planCategoryRepository.update(planCategory);
             }
             catch (Exception e){
-                throw new CustomException("계획 카테고리 수정에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);
+                throw new CustomException("계획 카테고리 수정에 실패했습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
             response.put("success", true);
             response.put("message", "계획 카테고리가 정상적으로 수정 되었습니다");
             return new ResponseEntity<>(response, HttpStatus.OK);
         }else{
-            throw new CustomException("해당 카테고리가 존재하지 않습니다.", HttpStatus.OK);
+            throw new CustomException("해당 카테고리가 존재하지 않습니다.", null, HttpStatus.OK);
         }
     }
 
@@ -119,7 +119,7 @@ public class PlanCategoryService {
             planCategoryRepository.delete(planCategory);
         }
         catch (Exception e){
-            throw new CustomException("계획 카테고리 삭제에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("계획 카테고리 삭제에 실패했습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         response.put("success", true);

--- a/src/main/java/com/example/iplan/Service/PlanChildService.java
+++ b/src/main/java/com/example/iplan/Service/PlanChildService.java
@@ -101,7 +101,7 @@ public class PlanChildService {
             //response = dayDataService.GenerateOrSaveDayPlanData(response, planPost, user_id);
             return new ResponseEntity<>(response, HttpStatus.OK);
         } else {
-            throw new CustomException("유저 아이디가 올바르지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("유저 아이디가 올바르지 않습니다.", null, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -117,11 +117,11 @@ public class PlanChildService {
 
         if(existingPlan == null){
             log.info("계획이 존재하지 않아 수정 불가");
-            throw new CustomException("해당 Id의 PlanChild 문서가 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("계획 수정 실패", "해당 ID: "+ planChildDTO.getId() +"가 PlanChild 문서에 없습니다.", HttpStatus.NOT_FOUND);
         }
         if(!Objects.equals(existingPlan.getUser_id(), user_id)) {
             log.info("계획 수정 권한이 없음");
-            throw new CustomException("해당 계획에 대한 수정 권한이 없습니다.", HttpStatus.UNAUTHORIZED);
+            throw new CustomException("계획 수정 실패", "해당 계획에 대한 수정 권한이 없습니다.", HttpStatus.UNAUTHORIZED);
         }
 
         // 1. 계획 업데이트
@@ -145,7 +145,7 @@ public class PlanChildService {
             log.info("계획 업데이트 성공!!");
         }
         catch (Exception e){
-            throw new CustomException("계획 업데이트에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("계획 업데이트에 실패했습니다", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         // 2. 알림 설정에 따른 푸시 예약 처리
@@ -205,7 +205,7 @@ public class PlanChildService {
                 }
             }
         }catch(Exception e){
-            throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         return planDtoList;
@@ -252,7 +252,7 @@ public class PlanChildService {
             PlanChild plan = planChildRepository.findEntityByDocumentId(document_id);
 
             if (plan == null)
-                throw new CustomException("해당 Id의 PlanChild 문서가 없습니다.", HttpStatus.NOT_FOUND);
+                throw new CustomException("계획 삭제 실패", "해당 ID: "+ document_id +"가 PlanChild 문서에 없습니다.", HttpStatus.NOT_FOUND);
 
             // 만약 알림 설정이 되어있는 계획이라면 예약된 푸시 알림 취소 + Alarm 컬렉션에서 삭제
             if (plan.isAlarm() && plan.getPlan_start_time() != null) {
@@ -268,7 +268,7 @@ public class PlanChildService {
             log.info("계획 삭제 완료: {}", plan.getId());
         }
         catch (Exception e){
-            throw new CustomException("계획 삭제에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("계획 삭제 실패", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         response.put("success", true);
@@ -296,7 +296,7 @@ public class PlanChildService {
             setScreenTimeRepository.saveWithAutoIncrement(newScreenTime);
         }
         catch(Exception e){
-            throw new CustomException("스크린 타임 설정에 실패했습니다. Error: "+ e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("스크린 타임 설정에 실패했습니다", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         response.put("success", true);

--- a/src/main/java/com/example/iplan/Service/PlanParentService.java
+++ b/src/main/java/com/example/iplan/Service/PlanParentService.java
@@ -83,17 +83,17 @@ public class PlanParentService {
             if (plan != null) {
                 // 계획의 user_id와 일치한지 확인
                 if (!Objects.equals(plan.getUser_id(), childNickname)) {
-                    throw new CustomException("해당 계획에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                    throw new CustomException("해당 계획에 대한 접근 권한이 없습니다.", null, HttpStatus.FORBIDDEN);  // 404 에러 반환
                 }
                 plan.setTitle(aes.decrypt(plan.getTitle()));
                 plan.setMemo(aes.decrypt(plan.getMemo()));
                 plan.setUser_id(aes.decrypt(plan.getUser_id()));
                 return Map.of("success", true, "message", planId + " 계획 반환 성공", "plan", plan);
             } else {
-                throw new CustomException(planId + " ID의 계획이 존재하지 않음", HttpStatus.NOT_FOUND);
+                throw new CustomException("계획 불러오기 실패", planId + " ID의 계획이 존재하지 않음", HttpStatus.NOT_FOUND);
             }
         } catch (Exception e) {
-            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
 

--- a/src/main/java/com/example/iplan/Service/RewardChildService.java
+++ b/src/main/java/com/example/iplan/Service/RewardChildService.java
@@ -1,7 +1,6 @@
 package com.example.iplan.Service;
 
 import com.example.iplan.DTO.RewardChildDTO;
-import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.RewardChildRepository;
@@ -62,7 +61,7 @@ public class RewardChildService {
             response.put("id", reward.getId());
             return new ResponseEntity<>(response, HttpStatus.OK);
         } catch (Exception e) {
-            throw new CustomException("보상 저장에 실패했습니다. Error: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("보상 저장에 실패했습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -78,14 +77,14 @@ public class RewardChildService {
                 // 보상의 user_id와 인증객체 유저와 일치한지 확인
                 log.info("아이쪽 단일 보상 조회 user_id : " + reward.getUser_id() + ", 요청 사용자 아이디: " + childNickname);
                 if (!Objects.equals(reward.getUser_id(), childNickname)) {
-                    throw new CustomException("해당 보상에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                    throw new CustomException("해당 보상에 대한 접근 권한이 없습니다.", null, HttpStatus.FORBIDDEN);  // 404 에러 반환
                 }
                 return Map.of("success", true, "message", rewardId + " 보상 반환 성공", "reward", reward);
             } else {
-                throw new CustomException(rewardId + " ID의 보상이 존재하지 않음", HttpStatus.NOT_FOUND);
+                throw new CustomException("일시적 오류가 발생하였습니다.",rewardId + " ID의 보상이 존재하지 않음", HttpStatus.NOT_FOUND);
             }
         } catch (Exception e) {
-            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -134,7 +133,13 @@ public class RewardChildService {
     public List<RewardChildDTO> getAllRewards(String nickname) throws Exception {
         // 사용자가 존재하는지 확인
         Users user = userRepository.findByEncryptedNickname(nickname)
-                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> {
+                    try {
+                        return new CustomException("일시적 오류가 발생하였습니다.", "user id: " + aes.decrypt(nickname) +"사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+                    } catch (Exception e) {
+                        throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
+                    }
+                });
         log.info("Get all rewards start!!");
         try {
             // 사용자의 모든 보상을 가져오기
@@ -172,12 +177,12 @@ public class RewardChildService {
             // 해당 ID의 보상을 조회
             RewardChild reward = rewardChildRepository.findEntityByDocumentId(documentID);
             if (reward == null) {
-                throw new CustomException("해당 ID의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+                throw new CustomException("보상 삭제 실패","해당 ID: "+ documentID +"의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
             }
 
             // 보상이 이미 지급된 경우 (is_rewarded 가 true) 삭제를 허용하지 않음
             if (reward.isRewarded()) {
-                throw new CustomException("해당 보상은 이미 지급되어 삭제할 수 없습니다.", HttpStatus.FORBIDDEN);
+                throw new CustomException("해당 보상은 이미 지급되어 삭제할 수 없습니다.", null, HttpStatus.FORBIDDEN);
             }
 
             // 지급되지 않은 보상만 삭제 허용
@@ -187,7 +192,7 @@ public class RewardChildService {
             response.put("message", "보상이 정상적으로 삭제되었습니다.");
             return new ResponseEntity<>(response, HttpStatus.OK);
         } catch (Exception e) {
-            throw new CustomException("보상 삭제에 실패했습니다. Error: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("보상 삭제에 실패했습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -205,7 +210,7 @@ public class RewardChildService {
         RewardChild existingReward = rewardChildRepository.findEntityByDocumentId(rewardDto.getId());
 
         if (existingReward == null) {
-            throw new CustomException("해당 ID의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("보상 수정 실패","해당 ID:" +rewardDto.getId()+ "의 보상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
 
         // 날짜 문자열에서 yyyy-MM-dd만 추출
@@ -224,7 +229,7 @@ public class RewardChildService {
         // 만약 해당 날짜의 보상이 이미 지급된 상태라면 수정 금지
         if (rewardChildOnSameDay != null && rewardChildOnSameDay.isRewarded()) {
             log.info("Error: reward is already rewarded");
-            throw new CustomException("해당 날짜의 보상이 이미 지급되어 수정할 수 없습니다.", HttpStatus.FORBIDDEN);
+            throw new CustomException("해당 날짜의 보상이 이미 지급되어 수정할 수 없습니다.", null, HttpStatus.FORBIDDEN);
         }
 
         RewardChild updatedReward = RewardChild.builder()
@@ -244,7 +249,7 @@ public class RewardChildService {
             log.info("Reward updated successfully!!");
             return new ResponseEntity<>(response, HttpStatus.OK);
         } catch (Exception e) {
-            throw new CustomException("보상 수정에 실패했습니다. Error: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("보상 수정 실패", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/example/iplan/Service/RewardParentsService.java
+++ b/src/main/java/com/example/iplan/Service/RewardParentsService.java
@@ -1,7 +1,6 @@
 package com.example.iplan.Service;
 
 import com.example.iplan.DTO.RewardChildDTO;
-import com.example.iplan.Domain.PlanChild;
 import com.example.iplan.Domain.RewardChild;
 import com.example.iplan.ExceptionHandler.CustomException;
 import com.example.iplan.Repository.RewardChildRepository;
@@ -51,7 +50,7 @@ public class RewardParentsService {
 
         // 사용자 존재 여부 확인
         Users user = userRepository.findByHashValueNickName(DigestUtils.sha256Hex(nickname))
-                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다: " + nickname, HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new CustomException("보상 불러오기 실패", "사용자 Id:" + nickname +"를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         try {
             List<RewardChildDTO> rewards = rewardChildRepository.findRewardChildDtoByUserId(user.getNickname());
@@ -92,17 +91,17 @@ public class RewardParentsService {
                 // 보상의 user_id와 인증객체 유저와 일치한지 확인
                 if (!Objects.equals(reward.getUser_id(), user.getNickname())) {
                     log.info("reward의 User_id: {}, Child의 닉네임: {}", reward.getUser_id(), user.getNickname());
-                    throw new CustomException("해당 보상에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN);  // 404 에러 반환
+                    throw new CustomException("해당 보상에 대한 접근 권한이 없습니다.", null, HttpStatus.FORBIDDEN);  // 404 에러 반환
                 }
                 reward.setUser_id(aes.decrypt(reward.getUser_id()));
                 reward.setContent(aes.decrypt(reward.getContent()));
 
                 return Map.of("success", true, "message", rewardId + " 보상 반환 성공", "reward", reward);
             } else {
-                throw new CustomException(rewardId + " ID의 보상이 존재하지 않음", HttpStatus.NOT_FOUND);
+                throw new CustomException("보상을 불러오는데 실패하였습니다.", rewardId + " ID의 보상이 존재하지 않음", HttpStatus.NOT_FOUND);
             }
         } catch (Exception e) {
-            throw new CustomException("서버 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
 

--- a/src/main/java/com/example/iplan/Service/ScreenTimeService.java
+++ b/src/main/java/com/example/iplan/Service/ScreenTimeService.java
@@ -18,7 +18,6 @@ import com.google.cloud.vision.v1.Image;
 import com.google.protobuf.ByteString;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -124,7 +123,7 @@ public class ScreenTimeService {
         InstalledApps savedInstalledApps = installedAppsRepository.findByUserId(user_id);
 
         if(user_id == null){
-            throw new CustomException("유저 상태를 확인해주세요.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("로그인 상태를 확인해주세요.", "유저 아이디가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
 
         if(installedApps != null){
@@ -145,7 +144,7 @@ public class ScreenTimeService {
             try {
                 // 1. 임시 파일로 저장
                 if (image == null || image.isEmpty()) {
-                    throw new CustomException("업로드된 파일이 없습니다.", HttpStatus.BAD_REQUEST);
+                    throw new CustomException("업로드된 파일이 없습니다.", null, HttpStatus.BAD_REQUEST);
                 }
 
                 String filename = image.getOriginalFilename();
@@ -165,7 +164,7 @@ public class ScreenTimeService {
                     Files.write(filePath, image.getBytes());
                     System.out.println("File written successfully to: " + filePath);
                 } catch (IOException e) {
-                    throw new CustomException("파일 저장 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+                    throw new CustomException("파일 저장 중 오류 발생", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
                 }
 
                 // 2. 파일 생성 시간 확인(캡쳐 시간 확인)
@@ -212,11 +211,11 @@ public class ScreenTimeService {
                     } catch (Exception e) {
                         DeleteFolderFiles(filePath);
                         log.error("OCR 처리 중 내부 오류 발생", e);
-                        throw new CustomException(e.getMessage(), HttpStatus.BAD_REQUEST);
+                        throw new CustomException("OCR 처리 중 내부 오류 발생", e.toString(), HttpStatus.BAD_REQUEST);
                     }
                 } else {
                     DeleteFolderFiles(filePath);
-                    throw new CustomException("파일 생성 시간이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+                    throw new CustomException("오늘 캡쳐된 사진이 아니거나 마감 시간이 지나지 않았습니다.", null, HttpStatus.BAD_REQUEST);
                 }
 
                 // 마지막에 임시 파일 삭제
@@ -226,10 +225,10 @@ public class ScreenTimeService {
             } catch (Exception e) {
                 System.out.println("Error: " + e.getMessage());
                 e.printStackTrace();
-                throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+                throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }else{
-            throw new CustomException("설치된 앱 목록이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("일시적 오류가 발생하였습니다.","사용자 설치 앱 목록을 가져오는데에 실패했습니다.", HttpStatus.NOT_FOUND);
         }
     }
 
@@ -243,7 +242,7 @@ public class ScreenTimeService {
                             Files.delete(path);
                             System.out.println("삭제된 파일: " + path);
                         } catch (IOException e) {
-                            throw new CustomException("파일 삭제 중 오류 발생", HttpStatus.BAD_REQUEST);
+                            throw new CustomException("파일 삭제 중 오류 발생", e.toString(), HttpStatus.BAD_REQUEST);
                         }
                     });
             System.out.println("모든 파일 삭제 완료.");
@@ -318,7 +317,7 @@ public class ScreenTimeService {
 
         } catch (Exception e) {
             System.out.println("OCR 처리 중 예외 발생: " + e);
-            throw new CustomException("OCR 처리 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("OCR 처리 중 오류가 발생했습니다.", e.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -353,14 +352,14 @@ public class ScreenTimeService {
 
             if(categories.isEmpty()){
                 log.info("사용자 기기에 추가되지 않은 어플이 있습니다.");
-                throw new CustomException("사진과 사용자 기기의 정보가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+                throw new CustomException("사진과 사용자 기기의 정보가 일치하지 않습니다. 올바른 사진을 올려주세요.", null, HttpStatus.BAD_REQUEST);
             }
             result.put(KEY_CATEGORIES, categories);
             return result;
         }catch(Exception e){
             System.out.println("Error: " + e.getMessage());
             e.printStackTrace();
-            throw new CustomException("추출된 텍스트 분석(filter)중 오류가 발생하였습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("추출된 텍스트 분석중 오류가 발생하였습니다.", e.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -384,7 +383,7 @@ public class ScreenTimeService {
             }
         } catch (Exception e) {
             System.out.println("Error: " + e.getMessage());
-            throw new CustomException("그래프 분석 중 오류가 발생하였습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("그래프 분석 중 오류가 발생하였습니다.", e.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -399,7 +398,7 @@ public class ScreenTimeService {
         var screenTimeData = setScreenTimeRepository.findByDate(user_id, LocalDate.now().toString());
         System.out.println(LocalDate.now());
         if(screenTimeData == null){
-            throw new CustomException("스크린 타임 시간이 설정되지 않았습니다!", HttpStatus.BAD_REQUEST);
+            throw new CustomException("스크린 타임 시간이 설정되지 않았습니다!", null, HttpStatus.BAD_REQUEST);
         }
 
         String deadLineTime = screenTimeData.getDeadLineTime();
@@ -421,7 +420,7 @@ public class ScreenTimeService {
 
     private String TimeFormatter(Matcher matcher) {
         if (!matcher.matches()) {
-            throw new CustomException("No Match Found", HttpStatus.BAD_REQUEST);
+            throw new CustomException("일시적 오류가 발생하였습니다.", "No Match Found: 그래프 분석 TimeFormatter", HttpStatus.BAD_REQUEST);
         }
 
         LocalTime parseTime = LocalTime.MIDNIGHT;

--- a/src/main/java/com/example/iplan/auth/CustomLogoutHandler.java
+++ b/src/main/java/com/example/iplan/auth/CustomLogoutHandler.java
@@ -48,7 +48,7 @@ public class CustomLogoutHandler implements LogoutHandler, LogoutSuccessHandler 
             jwtTokenProvider.destroyToken(token, "logout");
             log.info("토큰 무효화 처리 완료 (Redis Blacklist 등록)");
         } else {
-            throw new CustomException("Authorization 헤더가 없거나 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("일시적 오류가 발생하였습니다.", "Authorization 헤더가 없거나 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/main/java/com/example/iplan/auth/ParentsConsentService.java
+++ b/src/main/java/com/example/iplan/auth/ParentsConsentService.java
@@ -1,0 +1,88 @@
+package com.example.iplan.auth;
+
+import com.example.iplan.ExceptionHandler.CustomException;
+import com.example.iplan.util.AES256Encryptor;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ParentsConsentService {
+    private final JavaMailSender mailSender;
+    private final Firestore firestore;
+    private final AES256Encryptor aes;
+
+    public String sendParentsConsentRequestMail(String parentEmail){
+        try{
+            String token = UUID.randomUUID().toString();
+            String encryptParentEmail = aes.encrypt(parentEmail);
+            Timestamp expiresAt = Timestamp.ofTimeSecondsAndNanos(Instant.now().plusSeconds(180).getEpochSecond(),0); //3분으로 줄임
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("parentEmail", encryptParentEmail);
+            data.put("parentHashEmail", DigestUtils.sha256Hex(parentEmail));
+            data.put("expiresAt", expiresAt);
+            data.put("consent", false);
+
+            firestore.collection("ParentsConsentTokens").document(token).set(data).get();
+
+            String webRedirectLink = "https://iplanner.site/api/auth/consent/confirm?token=" + token;
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+            String html = "<p>안녕하세요. 귀하의 자녀가 iPlan(계획 달성 어플) 서비스를 이용하기 위해 가입을 시도하였습니다.\n" +
+                    "아래 버튼을 눌러 자녀의 가입에 동의해 주세요:</p>" +
+                    "<a href=\"" + webRedirectLink + "\">[동의합니다]</a>";
+            helper.setTo(parentEmail);
+            helper.setSubject("[iPlan] 자녀의 가입을 위한 보호자 동의 요청");
+            helper.setText(html, true);
+
+            mailSender.send(mimeMessage);
+
+            return token;
+
+        } catch (Exception e) {
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public ResponseEntity<?> confirmParentsConsent(String token) {
+        DocumentReference docRef = firestore.collection("ParentsConsentTokens").document(token);
+
+        try{
+            DocumentSnapshot snapshot = docRef.get().get();
+            if(!snapshot.exists()){
+                throw new CustomException("보호자 동의 시간이 만료되었습니다. 다시 시도해주세요", "보호자 동의 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+            }
+            Map<String, Object> updates = new HashMap<>();
+            updates.put("consent", true);
+            updates.put("confirmedAt", Timestamp.now());
+
+            docRef.update(updates);
+
+            return ResponseEntity.ok(Map.of(
+                    "message", "보호자 동의가 완료되었습니다."
+            ));
+        }catch (Exception e){
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/example/iplan/auth/PasswordResetService.java
+++ b/src/main/java/com/example/iplan/auth/PasswordResetService.java
@@ -45,7 +45,7 @@ public class PasswordResetService {
             firestore.collection("PasswordResetTokens").document(token).set(data).get();
 
             //테스트 시 본인 로컬 IP주소로 변경(추후 서버 주소로 변경)
-            String webRedirectLink = "https://iplanner.site/api/auth/reset-password-redirect?token=" + token;
+            String webRedirectLink = "https://iplanner.site/api/auth/mailsender-redirect?token=" + token;
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
 
@@ -60,7 +60,7 @@ public class PasswordResetService {
 
         }catch (Exception e){
             System.out.println(e.getMessage());
-            throw new CustomException(e.getMessage(), HttpStatus.BAD_REQUEST);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.BAD_REQUEST);
         }
 
     }
@@ -71,7 +71,7 @@ public class PasswordResetService {
 
         if(!doc.exists()) {
             System.out.println("유효하지 않는 토큰입니다.");
-            throw new CustomException("유효하지 않는 토큰입니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("비밀번호 재설정 시간이 만료되었습니다. 다시 시도해주세요.", "비밀번호 재설정 토큰이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
 
         System.out.println(doc);
@@ -80,7 +80,7 @@ public class PasswordResetService {
         assert expiresAt != null;
         if(expiresAt.toDate().before(new java.util.Date())){
             System.out.println("토큰이 만료되었습니다.");
-            throw new CustomException("토큰이 만료되었습니다.", HttpStatus.REQUEST_TIMEOUT);
+            throw new CustomException("비밀번호 재설정 시간이 만료되었습니다. 다시 시도해주세요.", null, HttpStatus.BAD_REQUEST);
         }
 
         String email = doc.getString("email"); // 암호화된 이메일 그대로 가져오기

--- a/src/main/java/com/example/iplan/auth/UserController.java
+++ b/src/main/java/com/example/iplan/auth/UserController.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 public class UserController {
     private final UserService userService;
     private final PasswordResetService passwordResetService;
+    private final ParentsConsentService parentsConsentService;
     private final JwtTokenProvider jwtTokenProvider;
     private final AES256Encryptor aes;
 
@@ -155,7 +156,7 @@ public class UserController {
 
         String roleStr = requestBody.get("role");
         if (roleStr == null || (!roleStr.equals("ROLE_CHILD") && !roleStr.equals("ROLE_PARENT"))) {
-            throw new CustomException("사용자 역할이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("사용자 역할이 존재하지 않습니다.", null, HttpStatus.BAD_REQUEST);
         }
 
         // 사용자 역할 업데이트
@@ -186,7 +187,7 @@ public class UserController {
 
     private static Authentication getAuthentication(Users updatedUser) {
         if (updatedUser == null) {
-            throw new CustomException("사용자가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("사용자가 존재하지 않습니다.", null, HttpStatus.NOT_FOUND);
         }
 
         // 추가 정보가 반영된 유저로 CustomOAuth2UserDetails 객체 생성
@@ -207,7 +208,7 @@ public class UserController {
     public ResponseEntity<?> changePassword(@AuthenticationPrincipal CustomOAuth2UserDetails userDetails) {
         if (userDetails == null) {
             System.out.println("인증 사용자 정보가 존재하지 않습니다.");
-            throw new CustomException("인증 정보가 유효하지 않습니다. 다시 로그인 해주세요.", HttpStatus.BAD_REQUEST);
+            throw new CustomException("인증 정보가 유효하지 않습니다. 다시 로그인 해주세요.", null, HttpStatus.BAD_REQUEST);
         }
 
         try {
@@ -217,7 +218,7 @@ public class UserController {
             return ResponseEntity.ok(Map.of("message", "이메일 전송에 성공했습니다."));
         } catch (Exception e) {
             System.out.println("예외 발생: " + e.getMessage());
-            throw new CustomException("서버 오류가 발생했습니다: " + e.getMessage(), HttpStatus.BAD_REQUEST);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -244,8 +245,35 @@ public class UserController {
                     "message", "메일 전송에 성공하였습니다."
             ));
         }else{
-            throw new CustomException("해당 이메일에 등록된 사용자가 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("해당 이메일에 등록된 사용자가 없습니다.", null, HttpStatus.NOT_FOUND);
         }
+    }
+
+    @PostMapping("/auth/parents/consent/verify")
+    public ResponseEntity<?> verifyParentsConsent(@RequestBody Map<String, String> payload) {
+        String parentEmail = payload.get("parentEmail");
+
+        log.info("Parent: {}", parentEmail);
+
+        try{
+            if(parentEmail != null){
+                String token = parentsConsentService.sendParentsConsentRequestMail(parentEmail);
+                return ResponseEntity.ok(Map.of(
+                        "token", token,
+                        "message", "보호자 동의 메일을 성공적으로 보냈습니다."
+                ));
+            }else{
+                throw new CustomException("이메일을 입력해주세요.", null, HttpStatus.BAD_REQUEST);
+            }
+        }catch (Exception e){
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+    }
+
+    @PostMapping("/api/auth/consent/confirm")
+    public ResponseEntity<?> confirmConsent(@RequestParam String token) throws ExecutionException, InterruptedException {
+        return parentsConsentService.confirmParentsConsent(token);
     }
 
     /**
@@ -267,7 +295,7 @@ public class UserController {
         ));
     }
 
-    @GetMapping("/auth/reset-password-redirect")
+    @GetMapping("/auth/mailsender-redirect")
     public ResponseEntity<String> redirectPage(@RequestParam String token) {
         String html = """
         <html>
@@ -310,7 +338,7 @@ public class UserController {
                     "message", "연결된 계정 삭제에 성공하였습니다."
             ));
         }else{
-            throw new CustomException("사용자의 이메일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+            throw new CustomException("사용자의 이메일을 찾을 수 없습니다.", null, HttpStatus.NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -18,7 +18,6 @@ import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import com.example.iplan.auth.redis.RefreshTokenService;
 import com.example.iplan.util.AES256Encryptor;
 import com.example.iplan.scheduler.PushSchedulerService;
-import com.google.api.Http;
 import com.google.api.client.util.Value;
 import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
@@ -73,7 +72,7 @@ public class UserService {
         try {
             // 1. 아이디 중복 확인 (닉네임 해시값으로 중복 비교)
             if (nickname != null && userRepository.findByHashValueNickName(DigestUtils.sha256Hex(nickname)).isPresent()) {
-                throw new CustomException("Nickname already exists.", HttpStatus.NOT_FOUND);
+                throw new CustomException("이미 존재하는 아이디입니다.", null, HttpStatus.NOT_FOUND);
             }
 
             // 2. authority Enum 변환
@@ -99,9 +98,9 @@ public class UserService {
 
             return "Sign Up Successfully";
         } catch (ExecutionException | InterruptedException e) {
-            throw new CustomException("Error accessing Firestore: " + e.getMessage(), HttpStatus.BAD_REQUEST);
+            throw new CustomException("일시적 오류가 발생하였습니다.", "Firestore 접근 오류: " + e, HttpStatus.BAD_REQUEST);
         } catch (Exception e) {
-            throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("일시적 오류가 발생하였습니다.", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -134,7 +133,7 @@ public class UserService {
 
             // 4. 사용자 정보 조회
             Users user = userRepository.findByHashValueNickName(DigestUtils.sha256Hex(user_id))
-                    .orElseThrow(() -> new CustomException("사용자 없음", HttpStatus.NOT_FOUND));
+                    .orElseThrow(() -> new CustomException("사용자 찾을 수 없습니다.", null, HttpStatus.NOT_FOUND));
 
             // 5. Firebase 사용자 생성 및 UID 저장
             if (user.getFirebaseAuthUID() == null || user.getFirebaseAuthUID().isBlank()) {
@@ -158,7 +157,7 @@ public class UserService {
                     }
                 } catch (Exception e) {
                     log.error("Firebase 사용자 생성 중 오류", e);
-                    throw new CustomException("Firebase 사용자 등록 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+                    throw new CustomException("로그인 실패", "Firebase 사용자 생성 중 오류 발생: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
                 }
             }
 
@@ -189,7 +188,7 @@ public class UserService {
             // 11. jwt 반환
             return jwtToken;
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인 실패: " + e.getMessage());
+            throw new CustomException("로그인 실패", e.toString(), HttpStatus.UNAUTHORIZED);
         }
     }
 
@@ -202,7 +201,7 @@ public class UserService {
     public String withdraw(String accessToken, String fcmToken, String encryptedUserId) throws ExecutionException, InterruptedException {
         String nickname = jwtTokenProvider.getUserNickname(accessToken);
         Users user = userRepository.findByHashValueNickName(DigestUtils.sha256Hex(nickname))
-                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다", null, HttpStatus.NOT_FOUND));
         String uid = user.getFirebaseAuthUID();
         log.info("계정 탈퇴 사용자 nickname: {}, Firebase uid: {}", nickname, uid);
 
@@ -225,7 +224,7 @@ public class UserService {
                 unlinkSocial(user.getProvider(), user.getProviderAccessToken());
             }catch (Exception e){
                 log.warn("소셜 연동 해제 실패 : {}", e.getMessage());
-                throw new CustomException("소셜 연동 해제 실패", HttpStatus.BAD_REQUEST);
+                throw new CustomException("소셜 연동 해제 실패", e.toString(), HttpStatus.BAD_REQUEST);
             }
             user.setProviderAccessToken(null); // 토큰 사용 후 파기
         }
@@ -248,7 +247,7 @@ public class UserService {
             log.info("Firebase 사용자 삭제 완료: {}", uid);
         } catch (FirebaseAuthException e) {
             log.error("Firebase 사용자 삭제 실패: {}", e.getMessage());
-            throw new CustomException("Firebase 사용자 삭제 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("회원 탈퇴 실패", "Firebase 사용자 삭제 실패: " + e, HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
         log.info("회원 탈퇴 완료: {}", nickname);
@@ -277,7 +276,7 @@ public class UserService {
             }
         }catch(Exception e){
             log.warn("{} 소셜 연동 해제 중 오류 발생: {}", provider, e.getMessage());
-            throw new CustomException("소셜 연동 해제 중 오류 발생", HttpStatus.BAD_REQUEST);
+            throw new CustomException("소셜 연동 해제 실패", e.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -432,7 +431,7 @@ public class UserService {
                         .get();
             } catch (InterruptedException | ExecutionException e) {
                 System.out.println("업데이트 실패: " + e.getMessage());
-                throw new CustomException("비밀번호 변경 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+                throw new CustomException("비밀번호 변경 실패", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }
 
@@ -515,11 +514,11 @@ public class UserService {
                     log.warn("연동 요청을 보낼 유저({})의 FcmToken이 존재하지 않습니다.", aes.decrypt(encryptedLinkedId));
                 }
             }catch (Exception e){
-                throw new CustomException(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+                throw new CustomException("연동 아이디 제거 실패", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
         }catch (Exception e){
-            throw new CustomException("연동 아이디 제거 중 오류 발생: "+ e.getMessage(), HttpStatus.BAD_REQUEST);
+            throw new CustomException("연동 아이디 제거 실패", e.toString(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -537,7 +536,7 @@ public class UserService {
             return new CustomOAuth2UserDetails(user);
         } catch (Exception e) {
             log.error("loadUserByEncryptedNickname 오류: {}", e.getMessage());
-            throw new CustomException("사용자 정보를 불러오는 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("사용자 정보 불러오기 실패", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/example/iplan/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/iplan/auth/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.example.iplan.auth.jwt;
 
-import com.example.iplan.ExceptionHandler.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -9,7 +8,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;

--- a/src/main/java/com/example/iplan/fcm/FcmTokenService.java
+++ b/src/main/java/com/example/iplan/fcm/FcmTokenService.java
@@ -73,12 +73,12 @@ public class FcmTokenService {
                 fcmTokenRepository.delete(tokenToDelete);
                 log.info("FCM 토큰 삭제 완료: hashedUserId={}, token={}", hashedUserId, token);
             } else {
-                throw new CustomException("삭제할 FCM 토큰이 존재하지 않음: token = " + token, HttpStatus.NOT_FOUND);
+                throw new CustomException("일시적 오류가 발생하였습니다.", "삭제할 FCM 토큰이 존재하지 않음: token = " + token, HttpStatus.NOT_FOUND);
             }
         } catch (ExecutionException | InterruptedException e) {
             log.error("FCM 토큰 삭제 실패", e);
             Thread.currentThread().interrupt();
-            throw new CustomException("FCM 토큰 삭제 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new CustomException("FCM 토큰 삭제 실패", e.toString(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 


### PR DESCRIPTION
[Feat]
만 14세 미만 아동은 법적대리인 인증을 받고 가입할 수 있도록, 보호자 동의 이메일을 보내는 Controller, Service 구현
- /api/auth/parents/consent/verify
- 메일 전송시, ParentsConsentTokens 컬렉션 문서 생성
- 보호자 동의시, ParentsConsentTokens consent, confirmedAt 필드 update