### PR TITLE
feat: 소셜 로그인부터 연동 해제까지 전체 OAuth2 파이프라인 구현 (OpenFeign + Redis 기반)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ java {
 	}
 }
 
+ext {
+	springCloudVersion = "2023.0.5"
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -23,7 +27,14 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'io.perfmark:perfmark-api:0.26.0'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'

--- a/src/main/java/com/example/iplan/IPlanApplication.java
+++ b/src/main/java/com/example/iplan/IPlanApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+@EnableFeignClients
 @EnableWebMvc
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 @ConfigurationPropertiesScan

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -7,6 +7,10 @@ import com.example.iplan.Repository.PlanChildRepository;
 import com.example.iplan.Repository.RewardChildRepository;
 import com.example.iplan.Service.AlarmService;
 import com.example.iplan.Service.PlanChildService;
+import com.example.iplan.auth.oauth2.DTO.KakaoTokenResponse;
+import com.example.iplan.auth.oauth2.DTO.NaverTokenResponse;
+import com.example.iplan.auth.oauth2.SocialClientService;
+import com.example.iplan.auth.redis.OAuth2ProviderTokenService;
 import com.example.iplan.fcm.FcmRequestDTO;
 import com.example.iplan.fcm.FcmRequestService;
 import com.example.iplan.fcm.FcmToken;
@@ -64,6 +68,9 @@ public class UserService {
     private final AlarmService alarmService;
     private final PushSchedulerService pushSchedulerService;
     private final FcmRequestService fcmRequestService;
+
+    private final OAuth2ProviderTokenService providerTokenService;
+    private final SocialClientService socialClientService;
 
     private final AES256Encryptor aes;
 
@@ -203,16 +210,19 @@ public class UserService {
 
     /**
      * 계정 탈퇴
-     * @param accessToken
-     * @param fcmToken
-     * @param encryptedUserId
      */
     public String withdraw(String accessToken, String fcmToken, String encryptedUserId) throws ExecutionException, InterruptedException {
-        String nickname = jwtTokenProvider.getUserNickname(accessToken);
-        Users user = userRepository.findByHashValueNickName(DigestUtils.sha256Hex(nickname))
+
+        Users user = userRepository.findByEncryptedNickname(encryptedUserId)
                 .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다", null, HttpStatus.NOT_FOUND, null));
+
+        String provider = user.getProvider();
+        String subject = user.getEmailHash();
+
+        String p_access = providerTokenService.getAccessToken(provider, subject).orElse(null);
+        String p_refresh = providerTokenService.getRefreshToken(provider, subject).orElse(null);
+
         String uid = user.getFirebaseAuthUID();
-        log.info("계정 탈퇴 사용자 nickname: {}, Firebase uid: {}", nickname, uid);
 
         // 1. FCM 토큰 삭제
         if (fcmToken != null && !fcmToken.isBlank()) {
@@ -220,14 +230,52 @@ public class UserService {
         }
 
         // 2. 소셜 연동 해제
-        if(user.getProvider() != null && user.getProviderAccessToken() != null){
+        if(provider != null) {
             try{
-                unlinkSocial(user.getProvider(), user.getProviderAccessToken());
-            }catch (Exception e){
-                log.warn("소셜 연동 해제 실패 : {}", e.getMessage());
-                throw new CustomException("소셜 연동 해제 실패", e.toString(), HttpStatus.BAD_REQUEST,e );
+                //unlinkSocial(user.getProvider(), user.getProviderAccessToken());
+                switch (provider){
+                    case "google" -> {
+                        // 구글은 refreshToken이 있으면 그걸로 바로 함
+                        String revokeToken = (p_refresh != null) ? p_refresh : p_access;
+                        if(revokeToken != null){
+                            socialClientService.unlinkGoogle(revokeToken);
+                        } else{
+                            log.warn("Google unlink: no token found. Skip remote revoke.");
+                        }
+                    }
+                    case "kakao" -> {
+                        if(p_access != null){
+                            socialClientService.unlinkKakaoByAccess(p_access);
+                        } else if(p_refresh != null){
+                            KakaoTokenResponse t = socialClientService.reissueKakaoToken(p_refresh);
+
+                            if(t.getAccessToken() != null){
+                                socialClientService.unlinkKakaoByAccess(t.getAccessToken());
+                            } else {
+                                log.warn("Kakao unlink: cannot reissue access. Skip remote revoke.");
+                            }
+                        } else {
+                            log.warn("Kakao unlink: no token. Skip remote revoke.");
+                        }
+                    }
+                    case "naver" -> {
+                        if(p_access == null && p_refresh != null){
+                            NaverTokenResponse t = socialClientService.reissueNaverToken(p_refresh);
+                            p_access = t.getAccessToken();
+                        }
+                        if(p_access != null){
+                            boolean ok = socialClientService.unlinkNaver(p_access);
+                            if(!ok) log.warn("네이버 연동 해제 실패");
+                        } else {
+                            log.warn("Naver unlink: no token available. Skip remote revoke.");
+                        }
+                    }
+                    default -> log.warn("알 수 없는 provider: {}", provider);
+                }
+            } finally {
+                // 로컬 정리 (항상)
+                providerTokenService.deleteAll(provider, subject);
             }
-            user.setProviderAccessToken(null); // 토큰 사용 후 파기
         }
 
         // 3. 관련 데이터 삭제 (계획, 보상, 피드백)
@@ -259,93 +307,8 @@ public class UserService {
         // 제일 마지막에 ! 토큰 무효화
         jwtTokenProvider.destroyToken(accessToken, "withdraw");
 
-        log.info("회원 탈퇴 완료: {}", nickname);
         return "Delete User Successfully";
     }
-
-    public void unlinkSocial(String provider, String providerAccessToken){
-        if(providerAccessToken == null || providerAccessToken.isBlank()){
-            log.warn("소셜 연동 해제 생략: 토큰 없음");
-            return;
-        }
-
-        try{
-            switch (provider.toUpperCase()){
-                case "KAKAO":
-                    unlinkKakao(providerAccessToken);
-                    break;
-                case "NAVER":
-                    unlinkNaver(providerAccessToken);
-                    break;
-                case "GOOGLE":
-                    unlinkGoogle(providerAccessToken);
-                    break;
-                default:
-                    log.warn("지원하지 않는 소셜 provider입니다: {}", provider);
-            }
-        }catch(Exception e){
-            log.warn("{} 소셜 연동 해제 중 오류 발생: {}", provider, e.getMessage());
-            throw new CustomException("소셜 연동 해제 실패", e.toString(), HttpStatus.BAD_REQUEST, e);
-        }
-    }
-
-    private void unlinkKakao(String accessToken){
-        String url = "https://kapi.kakao.com/v1/user/unlink";
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken);
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        HttpEntity<?> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = new RestTemplate().postForEntity(url, entity, String.class);
-
-        if(response.getStatusCode().is2xxSuccessful()){
-            log.info("카카오 연동 해제 성공");
-        }else{
-            log.warn("카카오 연도오 해제 실패 또는 이미 해제됨: {}", response.getBody());
-        }
-    }
-    private void unlinkGoogle(String accessToken) {
-        String url = "https://oauth2.googleapis.com/revoke?token=" + accessToken;
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        HttpEntity<?> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = new RestTemplate().postForEntity(url, entity, String.class);
-
-        if (response.getStatusCode().is2xxSuccessful()) {
-            log.info("구글 연동 해제 성공");
-        } else {
-            log.warn("구글 연동 해제 실패 또는 이미 해제됨: {}", response.getBody());
-        }
-    }
-
-    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
-    private String naverClientId;
-
-    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
-    private String naverClientSecret;
-
-    private void unlinkNaver(String accessToken) {
-        String url = "https://nid.naver.com/oauth2.0/token" +
-                "?grant_type=delete" +
-                "&client_id=" + naverClientId +
-                "&client_secret=" + naverClientSecret +
-                "&access_token=" + accessToken +
-                "&service_provider=NAVER";
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        HttpEntity<?> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = new RestTemplate().postForEntity(url, entity, String.class);
-
-        if (response.getStatusCode().is2xxSuccessful()) {
-            log.info("네이버 연동 해제 성공");
-        } else {
-            log.warn("네이버 연동 해제 실패 또는 이미 해제됨: {}", response.getBody());
-        }
-    }
-
 
     /**
      * 닉네임을 기반으로 사용자 조회

--- a/src/main/java/com/example/iplan/auth/Users.java
+++ b/src/main/java/com/example/iplan/auth/Users.java
@@ -51,9 +51,6 @@ public class Users {
     @Schema(description = "어떤 소셜 플랫폼인지에 대한 정보", example = "google")
     private String provider;
 
-    @Schema(description = "소셜 플랫폼에서 받은 access token")
-    private String providerAccessToken;
-
     @Schema(description = "Firebase Auth가 생성한 UID (실시간 데이터 변경 감지를 위해)")
     private String firebaseAuthUID;
 }

--- a/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/CustomOAuth2UserService.java
@@ -47,7 +47,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        String oAuth2AccessToken = userRequest.getAccessToken().getTokenValue();
 
         // 플랫폼별 사용자 정보 매핑
         // OAuth2UserInfo.of()를 호출하여 표준화된 사용자 정보로 변환
@@ -63,7 +62,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 
         // 사용자 저장 또는 업데이트 -> user 설정(반환)
-        saveOrUpdate(oAuth2UserInfo, registrationId, oAuth2AccessToken);
+        saveOrUpdate(oAuth2UserInfo, registrationId);
         if (user == null) {
             throw new OAuth2AuthenticationException(
                     new OAuth2Error("user_null", "OAuth2 로그인 중 사용자 정보가 정상적으로 저장되지 않았습니다.", null)
@@ -76,14 +75,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     /**
      * 디비에서 사용자 정보를 조회하고, 없으면 새로 저장
      */
-    private void saveOrUpdate(OAuth2UserInfo oAuth2UserInfo, String provider, String providerAccessToken) {
+    private void saveOrUpdate(OAuth2UserInfo oAuth2UserInfo, String provider) {
         try {
             Optional<Users> existingUser = userRepository.findByHashValueEmail(DigestUtils.sha256Hex(oAuth2UserInfo.getEmail()));
             if (existingUser.isPresent()) {
                 // 1. 기존 회원이 로그인하는 경우
                 user = existingUser.get();
                 user.setProvider(provider);
-                user.setProviderAccessToken(providerAccessToken);
                 userRepository.update(user);
 
                 // 일반 로그인 사용자라면 소셜 로그인 거부 -> 비밀번호가 null 이 아님
@@ -114,7 +112,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .linked_id(new ArrayList<>())
                         .firebaseAuthUID("") // OAuth2SuccessHandler 에서 저장
                         .provider(provider)
-                        .providerAccessToken(providerAccessToken)
                         .build();
                 userRepository.saveWithAutoIncrement(user);
 

--- a/src/main/java/com/example/iplan/auth/oauth2/DTO/KakaoTokenResponse.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/DTO/KakaoTokenResponse.java
@@ -1,0 +1,25 @@
+package com.example.iplan.auth.oauth2.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken; // 내려올 수도 있음
+
+    @JsonProperty("refresh_token_expires_in")
+    private Long refreshTokenExpiresIn;
+
+    private String scope;
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/DTO/NaverTokenResponse.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/DTO/NaverTokenResponse.java
@@ -1,0 +1,18 @@
+package com.example.iplan.auth.oauth2.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class NaverTokenResponse {
+
+    @JsonProperty("access_token") private String accessToken;
+
+    @JsonProperty("expires_in") private String expiresIn;
+
+    @JsonProperty("refresh_token") private String refreshToken;
+
+    @JsonProperty("token_type") private String tokenType;
+
+    private String scope;
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/GoogleRefreshTokenRequestResolver.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/GoogleRefreshTokenRequestResolver.java
@@ -1,0 +1,48 @@
+package com.example.iplan.auth.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GoogleRefreshTokenRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    public GoogleRefreshTokenRequestResolver(ClientRegistrationRepository repo, String authorizationRequestBaseUri) {
+        this.delegate = new DefaultOAuth2AuthorizationRequestResolver(repo, authorizationRequestBaseUri);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return customize(delegate.resolve(request));
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return customize(delegate.resolve(request, clientRegistrationId));
+    }
+
+    private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest req){
+        if(req == null) return null;
+
+        String registrationId = req.getAttribute(OAuth2ParameterNames.REGISTRATION_ID);
+        if(!"google".equals(registrationId)){
+            return req; // 구글 외에는 그대로
+        }
+
+        // 기존 파라미터 + 추가 파라미터 병합
+        Map<String, Object> extra = new HashMap<>(req.getAdditionalParameters());
+        extra.put("access_type", "offline"); // refresh_token 발급 트리거
+        extra.put("prompt", "consent"); // 이미 동의한 사용자도 재동의 유도(최초 1회 보장)
+
+        return OAuth2AuthorizationRequest.from(req)
+                .additionalParameters(extra)
+                .build();
+    }
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/Interface/GoogleClient.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/Interface/GoogleClient.java
@@ -1,0 +1,21 @@
+package com.example.iplan.auth.oauth2.Interface;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.util.MultiValueMap;
+
+@FeignClient(name = "googleClient", url = "https://oauth2.googleapis.com")
+public interface GoogleClient {
+
+    @PostMapping(value = "/token",
+            consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    GoogleTokenResponse reissueToken(@RequestBody MultiValueMap<String,String> form);
+    // form: grant_type=refresh_token, client_id, client_secret, refresh_token
+
+    @PostMapping(value = "/revoke",
+            consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    feign.Response revoke(@RequestBody MultiValueMap<String,String> form);
+    // form: token=<refresh 또는 access>
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/Interface/KakaoApiClient.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/Interface/KakaoApiClient.java
@@ -1,0 +1,41 @@
+package com.example.iplan.auth.oauth2.Interface;
+
+import lombok.Data;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.util.MultiValueMap;
+
+@FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com")
+public interface KakaoApiClient {
+
+    /**
+     * 카카오 어드민키로 소셜 연동 해제
+     * @param adminAuth
+     * @param form
+     * @return
+     */
+    @PostMapping(value = "/v1/user/unlink",
+            consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    Long unlinkByAdmin(
+            @RequestHeader("Authorization") String adminAuth, // "KakaoAK {ADMIN_KEY}"
+            @RequestBody MultiValueMap<String,String> form
+            // form: target_id_type=user_id, target_id={숫자}
+    );
+
+    /**
+     * access token 방식으로 소셜 연동 해제
+     * @param bearer
+     * @param form
+     * @return
+     */
+    @PostMapping(value = "/v1/user/unlink",
+            consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    Long unlinkByAccess(
+            @RequestHeader("Authorization") String bearer, // "Bearer {accessToken}"
+            @RequestBody MultiValueMap<String,String> form // 비워도 됨
+    );
+}
+
+

--- a/src/main/java/com/example/iplan/auth/oauth2/Interface/KakaoAuthClient.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/Interface/KakaoAuthClient.java
@@ -1,0 +1,18 @@
+package com.example.iplan.auth.oauth2.Interface;
+
+import com.example.iplan.auth.oauth2.DTO.KakaoTokenResponse;
+import com.google.api.client.auth.oauth2.TokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakaoAuthClient", url = "https://kauth.kakao.com")
+public interface KakaoAuthClient {
+
+    @PostMapping(value = "/oauth/token",
+            consumes = org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    KakaoTokenResponse reissueToken(@RequestBody MultiValueMap<String,String> form);
+    // form: grant_type=refresh_token, client_id, client_secret(필요 시), refresh_token
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/Interface/NaverClient.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/Interface/NaverClient.java
@@ -1,0 +1,21 @@
+package com.example.iplan.auth.oauth2.Interface;
+
+import com.example.iplan.auth.oauth2.DTO.NaverTokenResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "naverClient", url = "https://nid.naver.com")
+public interface NaverClient {
+    @PostMapping(value = "/oauth2.0/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    NaverTokenResponse reissueToken(@RequestBody MultiValueMap<String,String> form);
+    // form: grant_type=refresh_token, client_id, client_secret, refresh_token
+
+    @PostMapping(value = "/oauth2.0/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    String unlink(@RequestBody MultiValueMap<String,String> form);
+    // form: grant_type=delete, client_id, client_secret, access_token, service_provider=NAVER
+}

--- a/src/main/java/com/example/iplan/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/OAuth2SuccessHandler.java
@@ -6,6 +6,7 @@ import com.example.iplan.auth.Users;
 import com.example.iplan.auth.jwt.JwtProperties;
 import com.example.iplan.auth.jwt.JwtToken;
 import com.example.iplan.auth.jwt.JwtTokenProvider;
+import com.example.iplan.auth.redis.OAuth2ProviderTokenService;
 import com.example.iplan.auth.redis.RefreshToken;
 import com.example.iplan.auth.redis.RefreshTokenService;
 import com.example.iplan.util.AES256Encryptor;
@@ -18,12 +19,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.User;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
 
 /**
  * OAuth2 로그인 성공 후 JWT 발급 및 React Native 앱으로 리다이렉트 처리
@@ -39,6 +48,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final AES256Encryptor aes;
     private final JwtProperties jwtProperties;
     private final RefreshTokenService refreshTokenService;
+
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final OAuth2ProviderTokenService providerTokenService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -88,8 +100,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        log.info("OAuth2 Access Token: {}", jwtToken.getAccessToken());
-        log.info("OAuth2 Refresh Token: {}", jwtToken.getRefreshToken());
 
         // Refresh 토큰 Redis 에 저장
         long expirationMinutes = jwtProperties.getRefreshTokenExpiration() / 1000 / 60; // ms → minutes
@@ -108,5 +118,34 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         log.info("OAuth2 Redirect to : {}", redirectUrl);
         response.sendRedirect(redirectUrl);
+
+        // 새로 추가!!
+        // OAuth2 토큰을 AuthorizedClient에서 꺼내 Redis 저장
+        if(authentication instanceof OAuth2AuthenticationToken oauthToken){
+            String registrationId = oauthToken.getAuthorizedClientRegistrationId(); //google, kakao, naver
+            OAuth2AuthorizedClient client =
+                    authorizedClientService.loadAuthorizedClient(registrationId, oauthToken.getName());
+
+            if(client != null){
+                OAuth2AccessToken accessToken = client.getAccessToken();
+                OAuth2RefreshToken refreshToken = client.getRefreshToken();
+
+                String subject = user.getEmailHash();
+
+                if(accessToken != null && accessToken.getTokenValue() != null){
+                    Instant now = Instant.now();
+                    Instant exp = Objects.requireNonNullElse(accessToken.getExpiresAt(), now.plusSeconds(3600));
+                    long ttlSec = Math.max(10, exp.getEpochSecond() - now.getEpochSecond());
+                    providerTokenService.saveAccessToken(registrationId, subject,accessToken.getTokenValue(), Duration.ofSeconds(ttlSec));
+                }
+                if(refreshToken != null && refreshToken.getTokenValue() != null){
+                    // 구글은 refresh 명시 만료 없음 ->  넉넉히, 카카오는 refresh_token_expires_in 활용가능
+                    providerTokenService.saveRefreshToken(registrationId,subject,refreshToken.getTokenValue(), Duration.ofDays(180));
+                }
+                log.info("Saved OAuth2 tokens to Redis. provider={}, subject={}", registrationId, subject);
+            }else{
+                log.warn("AuthorizedClient not found. provider={}", oauthToken.getAuthorizedClientRegistrationId());
+            }
+        }
     }
 }

--- a/src/main/java/com/example/iplan/auth/oauth2/SocialClientService.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/SocialClientService.java
@@ -1,0 +1,168 @@
+package com.example.iplan.auth.oauth2;
+
+import com.example.iplan.auth.oauth2.DTO.KakaoTokenResponse;
+import com.example.iplan.auth.oauth2.DTO.NaverTokenResponse;
+import com.example.iplan.auth.oauth2.Interface.KakaoApiClient;
+import com.example.iplan.auth.oauth2.Interface.KakaoAuthClient;
+import com.example.iplan.auth.oauth2.Interface.NaverClient;
+import com.example.iplan.auth.oauth2.Interface.GoogleClient;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SocialClientService {
+
+    private final GoogleClient googleClient;
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoApiClient kakaoApiClient;
+    private final NaverClient naverClient;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleClientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret:}")
+    private String kakaoClientSecret;
+
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
+
+    /**
+     * Google 토큰 갱신 요청
+     * @param refreshToken
+     * @return
+     */
+    public GoogleTokenResponse reissueGoogleToken(String refreshToken) {
+        var form = new LinkedMultiValueMap<String,String>();
+
+        form.add("grant_type", "refresh_token");
+        form.add("client_id", googleClientId);
+        form.add("client_secret", googleClientSecret);
+        form.add("refresh_token", refreshToken);
+
+        return googleClient.reissueToken(form);
+    }
+
+    /**
+     * Google 연결 해제 요청
+     * @param token
+     */
+    public void unlinkGoogle(String token) {
+        var form = new LinkedMultiValueMap<String,String>();
+        form.add("token", token); // refresh 권장
+
+        try {
+            googleClient.revoke(form);
+            log.info("Google unlink 요청 완료");
+
+        } catch (feign.FeignException e) {
+            log.warn("Google unlink 실패: status={}, body={}", e.status(), e.contentUTF8());
+            // 로컬 언링크는 계속 진행하도록 상위에서 분기
+        }
+    }
+
+    /**
+     * Kakao 토큰 갱신 요청
+     * @param refreshToken
+     * @return
+     */
+    public KakaoTokenResponse reissueKakaoToken(String refreshToken) {
+        var form = new LinkedMultiValueMap<String,String>();
+        form.add("grant_type", "refresh_token");
+        form.add("client_id", kakaoClientId);
+
+        if (kakaoClientSecret != null && !kakaoClientSecret.isBlank())
+            form.add("client_secret", kakaoClientSecret);
+
+        form.add("refresh_token", refreshToken);
+
+        return kakaoAuthClient.reissueToken(form);
+    }
+
+    /**
+     * 카카오 어드민키로 소셜 연동 해제
+     * @param kakaoUserId
+     * @return
+     */
+    public Long unlinkKakaoByAdmin(long kakaoUserId) {
+        var form = new LinkedMultiValueMap<String,String>();
+        form.add("target_id_type", "user_id");
+        form.add("target_id", String.valueOf(kakaoUserId));
+
+        try {
+            var res = kakaoApiClient.unlinkByAdmin("KakaoAK " + kakaoAdminKey, form);
+            log.info("Kakao unlink(Admin) 성공: id={}", res);
+            return res;
+
+        } catch (feign.FeignException e) {
+            log.warn("Kakao unlink(Admin) 실패: status={}, body={}", e.status(), e.contentUTF8());
+            return null;
+        }
+    }
+
+    /**
+     * Kakao 연결 해제 요청
+     * @param accessToken
+     */
+    public Long unlinkKakaoByAccess(String accessToken) {
+        var form = new org.springframework.util.LinkedMultiValueMap<String,String>();
+
+        try {
+            var res = kakaoApiClient.unlinkByAccess("Bearer " + accessToken, form);
+            log.info("Kakao unlink(Access) 성공: id={}", res);
+            return res;
+
+        } catch (feign.FeignException e) {
+            log.warn("Kakao unlink(Access) 실패: status={}, body={}", e.status(), e.contentUTF8());
+            return null;
+        }
+    }
+
+    public NaverTokenResponse reissueNaverToken(String refreshToken) {
+        var form = new LinkedMultiValueMap<String,String>();
+
+        form.add("grant_type", "refresh_token");
+        form.add("client_id", naverClientId);
+        form.add("client_secret", naverClientSecret);
+        form.add("refresh_token", refreshToken);
+
+        return naverClient.reissueToken(form);
+    }
+
+    public boolean unlinkNaver(String accessToken){
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "delete");
+        form.add("client_id", naverClientId);
+        form.add("client_secret", naverClientSecret);
+        form.add("access_token", accessToken);
+        form.add("service_provider", "NAVER");
+
+        var res = naverClient.unlink(form);
+        boolean ok = "success".equalsIgnoreCase(res);
+        if (ok) {
+            log.info("NAVER unlink success");
+        } else {
+            log.warn("NAVER unlink failed: error={}", res);
+        }
+        return ok;
+    }
+
+}

--- a/src/main/java/com/example/iplan/auth/redis/OAuth2ProviderTokenService.java
+++ b/src/main/java/com/example/iplan/auth/redis/OAuth2ProviderTokenService.java
@@ -1,0 +1,52 @@
+package com.example.iplan.auth.redis;
+
+import com.example.iplan.util.AES256Encryptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2ProviderTokenService {
+
+    private final StringRedisTemplate redis;
+
+    private static final String ACCESS_FMT = "oauth:access:%s:%s";
+    private static final String REFRESH_FMT = "oauth:refresh:%s:%s";
+
+    public void saveAccessToken(String provider, String subject, String token, Duration ttl){
+        String key = REFRESH_FMT.formatted(provider, subject);
+        if(ttl != null){
+            redis.opsForValue().set(key, token, ttl);
+        }else{
+            redis.opsForValue().set(key, token);
+        }
+    }
+
+    public void saveRefreshToken(String provider, String subject, String token, Duration ttlOrNull) {
+        String key = REFRESH_FMT.formatted(provider, subject);
+        if (ttlOrNull != null) {
+            redis.opsForValue().set(key, token, ttlOrNull);
+        } else {
+            redis.opsForValue().set(key, token);
+        }
+    }
+
+    public Optional<String> getAccessToken(String provider, String subject){
+        String key = ACCESS_FMT.formatted(provider, subject);
+        return Optional.ofNullable(redis.opsForValue().get(key));
+    }
+
+    public Optional<String> getRefreshToken(String provider, String subject){
+        String key = REFRESH_FMT.formatted(provider, subject);
+        return Optional.ofNullable(redis.opsForValue().get(key));
+    }
+
+    public void deleteAll(String provider, String subject){
+        redis.delete(ACCESS_FMT.formatted(provider, subject));
+        redis.delete(REFRESH_FMT.formatted(provider, subject));
+    }
+}

--- a/src/main/java/com/example/iplan/config/SecurityConfig.java
+++ b/src/main/java/com/example/iplan/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.iplan.auth.CustomLogoutHandler;
 import com.example.iplan.auth.ExceptionHandler.CustomAccessDeniedHandler;
 import com.example.iplan.auth.ExceptionHandler.CustomAuthenticationEntryPoint;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserService;
+import com.example.iplan.auth.oauth2.GoogleRefreshTokenRequestResolver;
 import com.example.iplan.auth.oauth2.OAuth2FailureHandler;
 import com.example.iplan.auth.oauth2.OAuth2SuccessHandler;
 import com.example.iplan.auth.jwt.JwtAuthenticationFilter;
@@ -26,6 +27,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 @Slf4j
 @Configuration
@@ -40,9 +42,15 @@ public class SecurityConfig{
     private final CustomLogoutHandler customLogoutHandler;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private static final String OAUTH2_AUTHORIZATION_BASE_URI = "/oauth2/authorization";
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        var googleResolver = new GoogleRefreshTokenRequestResolver(
+                clientRegistrationRepository, OAUTH2_AUTHORIZATION_BASE_URI
+        );
 
         http
                 // 기본 설정인 Session 방식을 사용하지 않고 JWT를 사용하기 위해 STATELESS로 처리
@@ -83,6 +91,7 @@ public class SecurityConfig{
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(auth -> auth
                                 .baseUri("/oauth2/authorization") // 프론트에서 OAuth2 인증 요청 URL 설정
+                                .authorizationRequestResolver(googleResolver)
                         )
                         .redirectionEndpoint(redir -> redir
                                 .baseUri("/login/oauth2/code/*") // 카카오, 구글, 네이버에서 로그인 성공 후 백엔드로 인가 코드를 포함하여 보낼 리디렉션 URL 설정


### PR DESCRIPTION
## 📌 주요 내용

소셜 로그인(Google, Kakao, Naver)부터 연동 해제까지의 전체 OAuth2 파이프라인을 구현
OpenFeign 기반 외부 API 연동과 Redis 기반 토큰 저장 구조를 도입하여, 다음 기능들을 안정적으로 처리할 수 있도록 구성

---

## ✅ 구현 사항

### 1. 🔌 OpenFeign 연동
- `spring-cloud-starter-openfeign` 의존성 추가
- `@EnableFeignClients` 활성화
- 각 소셜 제공자(Google, Kakao, Naver)에 대한 FeignClient 인터페이스 정의

### 2. ☁️ 소셜 API 통합 서비스 구현
- `SocialClientService`에서 각 제공자의 토큰 재발급 및 연동 해제 로직을 통합 관리
- access_token 부재 시 → refresh_token으로 재발급하여 fallback 처리

### 3. 🔐 Google 리프레시 토큰 발급 지원
- `GoogleRefreshTokenRequestResolver` 구현
- `access_type=offline`, `prompt=consent` 파라미터를 구글 로그인 시에만 추가

### 4. 🧠 로그인 시 소셜 토큰 Redis 저장
- `OAuth2SuccessHandler`에서 OAuth2AuthorizedClient를 통해 access/refresh 토큰 추출
- provider + subject(emailHash) 기준 Redis에 저장 (TTL 관리 포함)

### 5. 🔄 탈퇴 시 연동 해제 처리
- Redis에서 access/refresh 토큰 조회
- 토큰 유무에 따라 동적으로 `unlink` 또는 `reissue → unlink` 처리
- 토큰이 모두 없을 경우에도 로컬 정리는 반드시 수행 (fallback 적용)

### 6. 🧹 로컬 데이터 정리
- 탈퇴 시:
  - 사용자 관련 FCM, 계획, 보상, 피드백 데이터 삭제
  - 소셜 토큰 Redis에서 삭제
  - 연동된 다른 사용자도 함께 연결 해제
  - Firebase Authentication 사용자 삭제
  - 최종 JWT 토큰 무효화

---

## 🛠 개선 사항 / 리팩토링

- `withdraw`에서 원격 언링크와 로컬 데이터 삭제를 명확히 분리
- 외부 API 호출 실패 여부와 관계없이 로컬 정리는 항상 수행되도록 구조 설계

---

## ⚠️ 주의할 점

- Google refresh_token 발급은 최초 로그인 시 1회만 발생. (access_type=offline + prompt=consent 조건 충족 필요)
- 카카오 연동 해제는 admin key 방식도 구현되어있으나 계정 탈퇴시엔 사용되지 않고 있음
- Redis 키 구조: `oauth:{access|refresh}:{provider}:{subject}` 형식으로 일관되게 관리됨

