### PR TITLE
[bugfix] 계획 푸시알림에서 해당 시간에 푸시알림이 오지 않는 오류 해결

### DIFF
--- a/src/main/java/com/example/iplan/fcm/FcmRequestService.java
+++ b/src/main/java/com/example/iplan/fcm/FcmRequestService.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import java.time.*;
 
 @Slf4j
 @Service
@@ -51,6 +52,11 @@ public class FcmRequestService {
                 .build();
 
         try {
+            // 현재 시각 로그 (서버/UTC/KST 동시)
+            Instant now = Instant.now();
+            ZonedDateTime nowKst = now.atZone(ZoneId.of("Asia/Seoul"));
+            log.info("푸시 발송 시각 - UTC: {}, KST: {}", now, nowKst);
+
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("FCM 전송 성공: {}",response);
 

--- a/src/main/java/com/example/iplan/scheduler/PushSchedulerService.java
+++ b/src/main/java/com/example/iplan/scheduler/PushSchedulerService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
+import java.time.*;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Date;
@@ -38,7 +39,9 @@ public class PushSchedulerService {
     public void schedulePushNotification(PlanChild plan, String fcmToken) {
         if (!plan.isAlarm()) return;
 
-        LocalDateTime targetTime = LocalDateTime.of(
+        // 1) 사용자 입력을 KST "지역 시각"으로 해석
+        ZoneId KST = ZoneId.of("Asia/Seoul");
+        LocalDateTime targetLocal = LocalDateTime.of(
                 Integer.parseInt(plan.getPost_year()),
                 Integer.parseInt(plan.getPost_month()),
                 Integer.parseInt(plan.getPost_day()),
@@ -46,9 +49,14 @@ public class PushSchedulerService {
                 Integer.parseInt(plan.getPlan_start_time().split(":")[1])
         );
 
-        long delay = Duration.between(LocalDateTime.now(), targetTime).toMillis();
+        // 2) 지역시각(KST)에 타임존을 붙여 UTC Instant로 변환
+        // targetLocal (2025-08-21T14:23) 에 Asia/Seoul 타임존을 붙임 → 2025-08-21T14:23+09:00[Asia/Seoul]
+        // 이걸 Instant로 바꾸면 → 2025-08-21T05:23:00Z (UTC)
+        Instant targetInstant = targetLocal.atZone(KST).toInstant();
+        log.info("계획 푸시알림 보낼 시간(UTC 기준의 절대 시각): {}", targetInstant);
 
-        if (delay <= 0) {
+        // 3) 과거 시간이면 스킵
+        if (targetInstant.isBefore(Instant.now())) {
             log.info("이미 지난 계획 → 푸시 생략");
             return;
         }
@@ -63,18 +71,18 @@ public class PushSchedulerService {
             }
         }
 
+        // 5) 스케줄 등록: '언제' 보낼지 명시
+        // 스케줄러는 절대 시각(epoch time) 기준으로 동작하기 때문에 → 한국에서 보기에 14:23에 정확히 실행
         PushTask task = new PushTask(plan, fcmToken, fcmRequestService, alarmService, aes);
-        Date executeAt = new Date(System.currentTimeMillis() + delay);
-        // 예약된 작업 저장
+        Date executeAt = Date.from(targetInstant);
         ScheduledFuture<?> future = taskScheduler.schedule(task, executeAt);
-
 
         // planId 기준으로 하위에 fcmToken별 future 저장
         scheduledTasks
                 .computeIfAbsent(plan.getId(), k -> new ConcurrentHashMap<>())
                 .put(fcmToken, future);
 
-        log.info("푸시 예약 완료: {} / 시간: {} / 토큰: {}", plan.getTitle(), targetTime, fcmToken);
+        log.info("푸시 예약 완료: {} / 시간: {} / 토큰: {}", plan.getTitle(), executeAt, fcmToken);
 
         // 푸시 예약 성공 후에만 알람 저장
         try {


### PR DESCRIPTION
- 스케줄 타임존 불일치 수정 (UTC 서버 vs KST 입력)
- KST(사용자 지역시각) → Instant로 변환해서 Date.from(instant)로 스케줄
- sendPush 메서드에서 언제 보냈는지(서버 시각/ UTC 시각/한국 시각) 로그 찍어서 추적