### PR TITLE
feat: 하나의 유저가 여러 기기(fcmToken)에서 로그인 가능하도록 로직 수정

### DIFF
--- a/src/main/java/com/example/iplan/auth/AuthController.java
+++ b/src/main/java/com/example/iplan/auth/AuthController.java
@@ -47,7 +47,10 @@ public class AuthController {
 
         String accessToken = request.getAccessToken();
         String refreshToken = request.getRefreshToken();
-        log.info("토큰 재발급 refreshToken: {}", refreshToken);
+        String fcmToken = request.getFcmToken();
+        log.info("토큰 재발급 요청 fcmToken: {}", fcmToken);
+        log.info("토큰 재발급 요청 accessToken: {}", accessToken);
+        log.info("토큰 재발급 요청 refreshToken: {}", refreshToken);
 
         // 1. accessToken 에서 암호화 되어있는!! nickname 추출
         String encryptedNickname;
@@ -60,8 +63,9 @@ public class AuthController {
                     .body(Map.of("message", "유효하지 않은 AccessToken 입니다."));
         }
 
-        // 2. Redis에서 refreshToken 조회 및 검증
-        Optional<RefreshToken> optional = refreshTokenService.getToken(encryptedNickname);
+        // 2. Redis 에서 refreshToken 조회 및 검증
+        // -> 유저 닉네임(암호화)과 기기 fcmToken 으로 조회(여러 기기에 로그인 가능하므로)
+        Optional<RefreshToken> optional = refreshTokenService.getToken(encryptedNickname, fcmToken);
       
         if (optional.isEmpty()) {
             return ResponseEntity
@@ -77,7 +81,7 @@ public class AuthController {
                     .body(Map.of("message", "RefreshToken이 일치하지 않습니다. 다시 로그인 해주세요."));
         }
 
-        // 3. DB에서 유저 정보 다시 조회 (최신 linked_id 등을 위해) 후 CustomOAuth2UserDetails 재생성
+        // 3. DB 에서 유저 정보 다시 조회 (최신 linked_id 등을 위해) 후 CustomOAuth2UserDetails 재생성
         CustomOAuth2UserDetails userDetails = userService.loadUserByEncryptedNickname(encryptedNickname);
 
         if (userDetails == null) {
@@ -105,7 +109,7 @@ public class AuthController {
             newToken = jwtTokenProvider.generateToken(authentication);
 
             long expirationMinutes = jwtProperties.getRefreshTokenExpiration() / 1000 / 60;
-            refreshTokenService.saveToken((CustomOAuth2UserDetails) authentication.getPrincipal(), newToken.getRefreshToken(), expirationMinutes);
+            refreshTokenService.saveToken((CustomOAuth2UserDetails) authentication.getPrincipal(), fcmToken, newToken.getRefreshToken(), expirationMinutes);
         } else {
 
             // 7. accessToken 은 항상 새로 발급

--- a/src/main/java/com/example/iplan/auth/CustomLogoutHandler.java
+++ b/src/main/java/com/example/iplan/auth/CustomLogoutHandler.java
@@ -45,7 +45,7 @@ public class CustomLogoutHandler implements LogoutHandler, LogoutSuccessHandler 
             }
 
             // 토큰 무효화 처리
-            jwtTokenProvider.destroyToken(token, "logout");
+            jwtTokenProvider.destroyToken(token, "logout", fcmToken);
             log.info("토큰 무효화 처리 완료 (Redis Blacklist 등록)");
         } else {
             throw new CustomException("일시적 오류가 발생하였습니다.", "로그아웃 오류: Authorization 헤더가 없거나 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST, null);

--- a/src/main/java/com/example/iplan/auth/DTO/TokenRefreshRequestDTO.java
+++ b/src/main/java/com/example/iplan/auth/DTO/TokenRefreshRequestDTO.java
@@ -12,4 +12,5 @@ import lombok.ToString;
 public class TokenRefreshRequestDTO {
     private String accessToken;
     private String refreshToken;
+    private String fcmToken;
 }

--- a/src/main/java/com/example/iplan/auth/UserService.java
+++ b/src/main/java/com/example/iplan/auth/UserService.java
@@ -204,6 +204,7 @@ public class UserService {
             long expirationMinutes = jwtProperties.getRefreshTokenExpiration() / 1000 / 60; // ms → minutes
             refreshTokenService.saveToken(
                     (CustomOAuth2UserDetails) authentication.getPrincipal(),
+                    fcmToken,
                     jwtToken.getRefreshToken(),
                     expirationMinutes
             );
@@ -317,7 +318,7 @@ public class UserService {
         }
 
         // 제일 마지막에 ! 토큰 무효화
-        jwtTokenProvider.destroyToken(accessToken, "withdraw");
+        jwtTokenProvider.destroyToken(accessToken, "withdraw", fcmToken);
 
         return "Delete User Successfully";
     }

--- a/src/main/java/com/example/iplan/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/iplan/auth/jwt/JwtTokenProvider.java
@@ -252,12 +252,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public void destroyToken(String accessToken, String reason) {
+    public void destroyToken(String accessToken, String reason, String fcmToken) {
         // 1. nickname 추출
         String nickname = getUserNickname(accessToken);
 
         // 2. Redis에서 RefreshToken 삭제
-        refreshTokenService.deleteToken(nickname);
+        refreshTokenService.deleteToken(nickname, fcmToken);
 
         // 3. accessToken 만료 시간 계산 → 현재 시간과의 차이로 TTL 계산
         Date expirationDate = getExpirationDate(accessToken);

--- a/src/main/java/com/example/iplan/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/iplan/auth/oauth2/OAuth2SuccessHandler.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * OAuth2 로그인 성공 후 JWT 발급 및 React Native 앱으로 리다이렉트 처리
@@ -62,7 +63,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         boolean isNewUser = customOAuth2UserService.isNewUser();
 
         if (user == null) {
-            log.error("OAuth2 login error: No user info");
+            log.error("OAuth2 소셜로그인 Error: No user info");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "OAuth2 로그인 중 사용자 정보가 없습니다.");
             return;
         }
@@ -104,20 +105,32 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
             throw new RuntimeException(e);
         }
 
-        // Refresh 토큰 Redis 에 저장
+        // Refresh 토큰 Redis 에 저장 (소셜로그인 시점: fcmToken 미정 → placeholder 사용)
+        // 1) 세션별 placeholder 생성
+        String sessionId = UUID.randomUUID().toString();
+        String placeholderFcm = "PENDING-" + sessionId;
         long expirationMinutes = jwtProperties.getRefreshTokenExpiration() / 1000 / 60; // ms → minutes
+
+        // 2) placeholder FCM 으로 RefreshToken 저장 (복합키: nickname:placeholderFcm)
         refreshTokenService.saveToken(
                 (CustomOAuth2UserDetails) authentication.getPrincipal(),
+                placeholderFcm,
                 jwtToken.getRefreshToken(),
                 expirationMinutes
         );
-        log.info("Refresh 토큰 Redis 에 저장: user_id={}, ttl={}min", user.getNickname(), expirationMinutes);
+        log.info("Refresh 토큰 Redis 저장 (placeholder): user={}, fcm={}, ttl={}min",
+                user.getNickname(), placeholderFcm, expirationMinutes);
+
 
         // React Native 앱으로 리다이렉트 (딥링크 사용)
-        String redirectUrl = String.format("iplan://auth-callback?accessToken=%s&refreshToken=%s&needsAdditionalInfo=%s",
+        // 3) 딥링크에 sessionId 추가하여 FE에 전달
+        String redirectUrl = String.format(
+                "iplan://auth-callback?accessToken=%s&refreshToken=%s&needsAdditionalInfo=%s&sessionId=%s",
                 URLEncoder.encode(jwtToken.getAccessToken(), StandardCharsets.UTF_8),
                 URLEncoder.encode(jwtToken.getRefreshToken(), StandardCharsets.UTF_8),
-                isNewUser);
+                isNewUser,
+                URLEncoder.encode(sessionId, StandardCharsets.UTF_8)
+        );
 
         log.info("OAuth2 Redirect to : {}", redirectUrl);
         response.sendRedirect(redirectUrl);

--- a/src/main/java/com/example/iplan/auth/redis/RefreshToken.java
+++ b/src/main/java/com/example/iplan/auth/redis/RefreshToken.java
@@ -18,16 +18,28 @@ import java.util.concurrent.TimeUnit;
 @NoArgsConstructor
 public class RefreshToken {
     @Id
-    private String id;
+    private String id;            // 복합키: nickname:fcmtoken
+
+    private String nickname;      // 식별자(암호화된 닉네임) 별도 보관
+    private String fcmToken;      // 실제 기기 토큰(혹은 placeholder)
 
     private String refreshToken;
 
     @TimeToLive(unit = TimeUnit.MINUTES)
-    private Long expiration;
+    private Long expiration;      // 분 단위 TTL
 
-    public RefreshToken(CustomOAuth2UserDetails userDetails, String refreshToken, Long expiration){
-        this.id = userDetails.getUsername();    // 암호화 되어있는 사용자 닉네임이 식별자
+    public static String compositeKey(String nickname, String fcmToken) {
+        return nickname + ":" + (fcmToken == null ? "NULL" : fcmToken);
+    }
+
+    public RefreshToken(CustomOAuth2UserDetails userDetails,
+                        String fcmToken,
+                        String refreshToken,
+                        Long expiration){
+        this.nickname = userDetails.getUsername();     // 암호화된 닉네임
+        this.fcmToken = fcmToken;                      // 실제 또는 placeholder
         this.refreshToken = refreshToken;
         this.expiration = expiration;
+        this.id = compositeKey(this.nickname, this.fcmToken);
     }
 }

--- a/src/main/java/com/example/iplan/auth/redis/RefreshTokenService.java
+++ b/src/main/java/com/example/iplan/auth/redis/RefreshTokenService.java
@@ -2,35 +2,70 @@ package com.example.iplan.auth.redis;
 
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     // 저장 (로그인, 토큰 재발급 시 사용)
-    public void saveToken(CustomOAuth2UserDetails userDetails, String refreshToken, long expirationMinutes) {
-        RefreshToken token = new RefreshToken(userDetails, refreshToken, expirationMinutes);
+    public void saveToken(CustomOAuth2UserDetails userDetails,
+                          String fcmToken,
+                          String refreshToken,
+                          long expirationMinutes) {
+        RefreshToken token = new RefreshToken(userDetails, fcmToken, refreshToken, expirationMinutes);
+        log.info("Redis에 RefreshToken 저장: {}", token);
         refreshTokenRepository.save(token);
     }
 
-    // 삭제 (로그아웃 시 사용)
-    public void deleteToken(String nickname) {
-        refreshTokenRepository.deleteById(nickname);
+    // 삭제 (닉네임 + fcmToken 기준)
+    public void deleteToken(String nickname, String fcmToken) {
+        String key = RefreshToken.compositeKey(nickname, fcmToken);
+        log.info("Redis에서 RefreshToken 삭제 key: {}", key);
+        refreshTokenRepository.deleteById(key);
     }
 
-    // 조회 (재발급 시 검증용)
-    public Optional<RefreshToken> getToken(String nickname) {
-        return refreshTokenRepository.findById(nickname);
+    // 조회 (닉네임 + fcmToken 기준)
+    public Optional<RefreshToken> getToken(String nickname, String fcmToken) {
+        String key = RefreshToken.compositeKey(nickname, fcmToken);
+        return refreshTokenRepository.findById(key);
     }
 
-    // 검증 (nickname 기준 refreshToken 일치 여부 확인)
-    public boolean validateToken(String nickname, String requestRefreshToken) {
-        return refreshTokenRepository.findById(nickname)
+    // 검증 (닉네임 + fcmToken 기준 refreshToken 일치 여부 확인)
+    public boolean validateToken(String nickname, String fcmToken, String requestRefreshToken) {
+        return getToken(nickname, fcmToken)
                 .map(saved -> saved.getRefreshToken().equals(requestRefreshToken))
                 .orElse(false);
     }
+
+    /**
+     * 소셜로그인 시 임시 fcmToken(placeholder)로 저장한 엔트리를
+     * 실제 fcmToken 키로 "재바인딩" (키 마이그레이션)
+     */
+    public void rebindToFcmWithSessionId(String nickname, String sessionId, String newFcmToken) {
+        String oldFcm = "PENDING-" + sessionId;
+        String oldKey = RefreshToken.compositeKey(nickname, oldFcm);
+
+        refreshTokenRepository.findById(oldKey).ifPresent(old -> {
+            // 같은 nickname 으로 동일 fcmToken 엔트리가 이미 있다면 정리(선택)
+            String newKey = RefreshToken.compositeKey(nickname, newFcmToken);
+            refreshTokenRepository.deleteById(newKey);
+
+            RefreshToken migrated = new RefreshToken();
+            migrated.setNickname(old.getNickname());
+            migrated.setFcmToken(newFcmToken);
+            migrated.setRefreshToken(old.getRefreshToken());
+            migrated.setExpiration(old.getExpiration()); // 남은 TTL(분)
+            migrated.setId(newKey);
+
+            refreshTokenRepository.save(migrated);
+            refreshTokenRepository.deleteById(oldKey);
+        });
+    }
+
 }

--- a/src/main/java/com/example/iplan/fcm/FcmTokenController.java
+++ b/src/main/java/com/example/iplan/fcm/FcmTokenController.java
@@ -3,6 +3,7 @@ package com.example.iplan.fcm;
 import com.example.iplan.auth.UserRepository;
 import com.example.iplan.auth.Users;
 import com.example.iplan.auth.oauth2.CustomOAuth2UserDetails;
+import com.example.iplan.auth.redis.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,7 @@ public class FcmTokenController {
 
     private final FcmTokenService fcmTokenService;
     private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
 
     /**
      * 소셜로그인 이후 발급받은 FcmToken 저장
@@ -29,9 +31,18 @@ public class FcmTokenController {
     @PostMapping("/register-fcm-token")
     public ResponseEntity<?> registerFcmToken(@RequestBody Map<String, String> request, @AuthenticationPrincipal CustomOAuth2UserDetails customOAuth2UserDetails) {
         String fcmToken = request.get("fcmToken");
+        String sessionId = request.get("sessionId");    // FE가 딥링크로 전달받아 함께 보냄
+
         Users user = userRepository.findByEncryptedNickname(customOAuth2UserDetails.getUsername()).orElseThrow(() -> new IllegalArgumentException("User not found."));
 
         fcmTokenService.save(user.getNicknameHash(), fcmToken); // 또는 업데이트
+
+        // 1) 유저별 fcmToken 저장/갱신
+        fcmTokenService.save(user.getNicknameHash(), fcmToken);
+
+        // 2) placeholder → 실제 fcmToken 으로 키 마이그레이션
+        refreshTokenService.rebindToFcmWithSessionId(customOAuth2UserDetails.getUsername(), sessionId, fcmToken);
+
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
- RefreshToken에 fcmToken 추가 (레디스에 저장)
- 복합키(id = nickname:fcmToken) 구조로 바꾸고, 소셜로그인 직후엔 임시 fcm 토큰(placeholder) 으로 저장 → 프론트가 실제 fcmToken을 등록하면 키를 마이그레이션(rebind) 하는 흐름
- 소셜 로그인 직후 서버가 sessionId 를 생성해서 placeholder FCM(PENDING-<sessionId>) 로 Redis에 저장하고, 딥링크로 sessionId 를 FE에 넘긴 뒤, FE가 실제 fcmToken을 준비하면 sessionId와 함께 등록해서 placeholder → 실제 fcmToken 으로 “키 마이그레이션(rebind)”