### PR TITLE
feat: PlanChild에 tempId 필드 추가

### DIFF
--- a/src/main/java/com/example/iplan/DTO/PlanChildDTO.java
+++ b/src/main/java/com/example/iplan/DTO/PlanChildDTO.java
@@ -26,6 +26,9 @@ public class PlanChildDTO {
     @Schema(description = "계획 데이터 고유 ID", example = "12345")
     private String id;
 
+    @Schema(description = "프론트 낙관적 업데이트와 온스냅샷 감지가 동시에 이루어짐에 따라 필요한 매칭 id", example = "temp-2198722398")
+    private String temp_id;
+
     @Schema(description = "사용자 Nickname", example = "user123")
     private String user_id;
 

--- a/src/main/java/com/example/iplan/Domain/PlanChild.java
+++ b/src/main/java/com/example/iplan/Domain/PlanChild.java
@@ -24,6 +24,13 @@ public class PlanChild {
     @Schema(description = "계획 데이터 고유 ID", example = "12345")
     private String id; // Firestore 문서의 ID
 
+
+    // 서버에 계획이 저장되는 순간 온스냅샷이 실행되는데
+    // 만약 온스냅샷이 먼저 실행된다면 프론트에서 낙관전 업데이트를 위해 발급한 tempId가 치환이 되지 않을 수 있음
+    // -> tempId를 서버에도 같이 보내어 저장 후, 온스냅샷 감지 이후 단일 계획 반환 시에 tempId도 같이 반환하여 계획 필터링 하도록 함
+    @Schema(description = "프론트 낙관적 업데이트와 온스냅샷 감지가 동시에 이루어짐에 따라 필요한 매칭 id", example = "temp-2198722398")
+    private String temp_id;
+
     @NotNull
     @Schema(description = "사용자 닉네임", example = "user123")
     private String user_id;

--- a/src/main/java/com/example/iplan/Service/PlanChildService.java
+++ b/src/main/java/com/example/iplan/Service/PlanChildService.java
@@ -58,6 +58,7 @@ public class PlanChildService {
 
         // 계획 포스트에 해시된 유저 아이디 필드 추가
         PlanChild planPost = PlanChild.builder()
+                .temp_id(planPostDto.getTemp_id())
                 .user_id(user_id)
                 .hashed_user_id(hashedNickname)
                 .alarm(planPostDto.isAlarm())
@@ -127,6 +128,7 @@ public class PlanChildService {
         // 1. 계획 업데이트
         PlanChild updatePlan = PlanChild.builder()
                 .id(existingPlan.getId())
+                .temp_id(existingPlan.getTemp_id())
                 .user_id(user_id)
                 .hashed_user_id(existingPlan.getHashed_user_id())
                 .alarm(planChildDTO.isAlarm())


### PR DESCRIPTION
- 서버에 계획이 저장되는 순간 온스냅샷이 실행되는데, 만약 온스냅샷이 먼저 실행된다면 프론트에서 낙관전 업데이트를 위해 발급한 tempId가 치환이 되지 않을 수 있음
- tempId를 서버에도 같이 보내어 저장 후, 온스냅샷 감지 이후 단일 계획 반환 시에 tempId도 같이 반환하여 계획 필터링 하도록 함